### PR TITLE
Fix hooks not all being executed if the currently executing hook is cleaned up

### DIFF
--- a/src/Document.luau
+++ b/src/Document.luau
@@ -125,7 +125,9 @@ type SchemaError = Types.SchemaError
 local INTERNAL_SCHEMA_VERSION = 0
 
 local function runHooks(hooks: { () -> () })
-	for _, hook in hooks do
+	-- Clone the table instead of iterating backwards, so hooks are executed in the
+	-- order they were added
+	for _, hook in table.clone(hooks) do
 		hook()
 	end
 end

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -1823,6 +1823,67 @@ Test("Open Hooks cleanup run correctly", function()
 	assert(failRan)
 end)
 
+Test("Open Hooks run even if cleaned up while executing hooks", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local firstBeforeRan = false
+	local secondBeforeRan = false
+	local firstAfterRan = false
+	local secondAfterRan = false
+	local firstFailRan = false
+	local secondFailRan = false
+
+	local cleanupBefore1
+	cleanupBefore1 = document:HookBefore("Open", function()
+		cleanupBefore1()
+		firstBeforeRan = true
+	end)
+	local cleanupBefore2
+	cleanupBefore2 = document:HookBefore("Open", function()
+		cleanupBefore2()
+		secondBeforeRan = true
+	end)
+
+	local cleanupAfter1
+	cleanupAfter1 = document:HookAfter("Open", function()
+		cleanupAfter1()
+		firstAfterRan = true
+	end)
+	local cleanupAfter2
+	cleanupAfter2 = document:HookAfter("Open", function()
+		cleanupAfter2()
+		secondAfterRan = true
+	end)
+
+	local cleanupFail1
+	cleanupFail1 = document:HookFail("Open", function()
+		cleanupFail1()
+		firstFailRan = true
+	end)
+	local cleanupFail2
+	cleanupFail2 = document:HookFail("Open", function()
+		cleanupFail2()
+		secondFailRan = true
+	end)
+
+	local result = document:Open()
+	assert(result.success, "Open failed")
+	assert(firstBeforeRan)
+	assert(secondBeforeRan)
+	assert(firstAfterRan)
+	assert(secondAfterRan)
+	local resultClose = document:Close()
+	assert(resultClose.success, "Close failed")
+	assert(not firstFailRan)
+	assert(not secondFailRan)
+
+	mockDataStore.errors:addSimulatedErrors(5)
+	result = document:Open()
+	assert(not result.success, "Open succeeded")
+	assert(firstFailRan)
+	assert(secondFailRan)
+end)
+
 Test("Close Hooks run correctly", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
@@ -1896,6 +1957,68 @@ Test("Close Hooks cleanup run correctly", function()
 	assert(failRan)
 
 	document:Close()
+end)
+
+Test("Close Hooks run even if cleaned up while executing hooks", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local firstBeforeRan = false
+	local secondBeforeRan = false
+	local firstAfterRan = false
+	local secondAfterRan = false
+	local firstFailRan = false
+	local secondFailRan = false
+
+	local cleanupBefore1
+	cleanupBefore1 = document:HookBefore("Close", function()
+		cleanupBefore1()
+		firstBeforeRan = true
+	end)
+	local cleanupBefore2
+	cleanupBefore2 = document:HookBefore("Close", function()
+		cleanupBefore2()
+		secondBeforeRan = true
+	end)
+
+	local cleanupAfter1
+	cleanupAfter1 = document:HookAfter("Close", function()
+		cleanupAfter1()
+		firstAfterRan = true
+	end)
+	local cleanupAfter2
+	cleanupAfter2 = document:HookAfter("Close", function()
+		cleanupAfter2()
+		secondAfterRan = true
+	end)
+
+	local cleanupFail1
+	cleanupFail1 = document:HookFail("Close", function()
+		cleanupFail1()
+		firstFailRan = true
+	end)
+	local cleanupFail2
+	cleanupFail2 = document:HookFail("Close", function()
+		cleanupFail2()
+		secondFailRan = true
+	end)
+
+	local result = document:Open()
+	local resultClose = document:Close()
+	assert(result.success, "Open failed")
+	assert(resultClose.success, "Close failed")
+	assert(firstBeforeRan)
+	assert(secondBeforeRan)
+	assert(firstAfterRan)
+	assert(secondAfterRan)
+	assert(not firstFailRan)
+	assert(not secondFailRan)
+
+	document:Open()
+	mockDataStore.errors:addSimulatedErrors(5)
+	resultClose = document:Close()
+	assert(not resultClose.success, "Close succeeded")
+	assert(firstFailRan)
+	assert(secondFailRan)
 end)
 
 Test("Before Update Hooks run correctly", function()
@@ -2056,6 +2179,78 @@ Test("Fail Update Hooks cleanup run correctly", function()
 	document:Close()
 end)
 
+Test("Update Hooks run even if cleaned up while executing hooks", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local firstBeforeRan = false
+	local secondBeforeRan = false
+	local firstAfterRan = false
+	local secondAfterRan = false
+	local firstFailRan = false
+	local secondFailRan = false
+
+	local cleanupBefore1
+	cleanupBefore1 = document:HookBefore("Update", function()
+		cleanupBefore1()
+		firstBeforeRan = true
+	end)
+	local cleanupBefore2
+	cleanupBefore2 = document:HookBefore("Update", function()
+		cleanupBefore2()
+		secondBeforeRan = true
+	end)
+
+	local cleanupAfter1
+	cleanupAfter1 = document:HookAfter("Update", function()
+		cleanupAfter1()
+		firstAfterRan = true
+	end)
+	local cleanupAfter2
+	cleanupAfter2 = document:HookAfter("Update", function()
+		cleanupAfter2()
+		secondAfterRan = true
+	end)
+
+	local cleanupFail1
+	cleanupFail1 = document:HookFail("Update", function()
+		cleanupFail1()
+		firstFailRan = true
+	end)
+	local cleanupFail2
+	cleanupFail2 = document:HookFail("Update", function()
+		cleanupFail2()
+		secondFailRan = true
+	end)
+
+	local result = document:Open()
+
+	assert(result.success, "Open failed")
+
+	local updateResult = document:Update(function(data: TestData)
+		-- We don't really need to test for changes made here if the previous tests pass
+		return table.clone(data)
+	end)
+
+	assert(firstBeforeRan)
+	assert(secondBeforeRan)
+	assert(firstAfterRan)
+	assert(secondAfterRan)
+	assert(not firstFailRan)
+	assert(not secondFailRan)
+	assert(updateResult.success)
+
+	mockDataStore.errors:addSimulatedErrors(5)
+
+	document:Update(function(data: TestData)
+		return table.clone(data)
+	end)
+
+	assert(firstFailRan)
+	assert(secondFailRan)
+
+	document:Close()
+end)
+
 Test("Read Hooks cleanup run correctly", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
@@ -2131,6 +2326,66 @@ Test("Read Hooks run correctly", function()
 	document:Close()
 end)
 
+Test("Read Hooks run even if cleaned up while executing hooks", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local firstBeforeRan = false
+	local secondBeforeRan = false
+	local firstAfterRan = false
+	local secondAfterRan = false
+	local firstFailRan = false
+	local secondFailRan = false
+
+	local cleanupBefore1
+	cleanupBefore1 = document:HookBefore("Read", function()
+		cleanupBefore1()
+		firstBeforeRan = true
+	end)
+	local cleanupBefore2
+	cleanupBefore2 = document:HookBefore("Read", function()
+		cleanupBefore2()
+		secondBeforeRan = true
+	end)
+
+	local cleanupAfter1
+	cleanupAfter1 = document:HookAfter("Read", function()
+		cleanupAfter1()
+		firstAfterRan = true
+	end)
+	local cleanupAfter2
+	cleanupAfter2 = document:HookAfter("Read", function()
+		cleanupAfter2()
+		secondAfterRan = true
+	end)
+
+	local cleanupFail1
+	cleanupFail1 = document:HookFail("Read", function()
+		cleanupFail1()
+		firstFailRan = true
+	end)
+	local cleanupFail2
+	cleanupFail2 = document:HookFail("Read", function()
+		cleanupFail2()
+		secondFailRan = true
+	end)
+
+	local result = document:Open()
+	local resultRead = document:Read()
+	assert(result.success, "Open failed")
+	assert(resultRead.success, "Read failed")
+	assert(firstBeforeRan)
+	assert(secondBeforeRan)
+	assert(firstAfterRan)
+	assert(secondAfterRan)
+	assert(not firstFailRan)
+	assert(not secondFailRan)
+
+	mockDataStore.errors:addSimulatedErrors(5)
+	resultRead = document:Read()
+	assert(not resultRead.success, "Read succeeded")
+	assert(firstFailRan)
+	assert(secondFailRan)
+end)
 
 Test("Open Once Hooks run correctly", function()
 	local documentStore, mockDataStore = createTestDocumentStore()

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anthony0br/documentservice"
 description = "DataStores with full type checking, hooks, +more"
-version = "1.1.2"
+version = "1.1.3"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
Ran into this issue while using `document:OnceAfter`. The problem is that the `cleanupFn` returned by `HookAfter` mutates the table used to store hooks, so if the `cleanupFn` is called while executing the hook, the `runHooks` function can skip iterating over a hook due to `table.remove` shifting each hook back past the iteration index. This PR fixes the issue by changing `runHooks` to instead iterate over a cloned `hooks` table, which won't be mutated during iteration.

Also added tests for each hook to make sure this fixes the issue for every hook. I don't believe the `Once` hooks need to be tested, as under-the-hood they call the same `Hook` methods.