### PR TITLE
Document:AwaitOpen method

### DIFF
--- a/docs/waiting.md
+++ b/docs/waiting.md
@@ -4,20 +4,4 @@ sidebar_position: 7
 
 # Waiting for a Document to open
 
-A common question I am asked is how to wait for a document to open (on a different
-thread to the one which called `:Open`)
-This is how I do that currently:
-
-```lua
-local thread = coroutine.running()
-
-if not document:IsOpen() then
-    document:OnceAfter("Open", function()
-        task.defer(thread)
-    end)
-    coroutine.yield()
-end
-```
-
-Warning: this implementation could yield indefinitely. You could use `OnceFail`
-to prevent this.
+See `Document:AwaitOpen`.

--- a/docs/waiting.md
+++ b/docs/waiting.md
@@ -4,4 +4,4 @@ sidebar_position: 7
 
 # Waiting for a Document to open
 
-See `Document:AwaitOpen`.
+Find the `Document:AwaitOpen` method in the API.

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -670,8 +670,9 @@ function Document.IsOpen<T>(self: Document<T>): boolean
 end
 
 --[=[
-	Yields the current thread until the document has been opened.
-	Returns true if the document is open, false if the document failed to open.
+	Yields the current thread until the document has been opened by another thread.
+	Does not open the document on its own.
+	Returns true if the document is open, or false if the document failed to open.
 
 	@return boolean
 

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -661,12 +661,57 @@ function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxA
 end
 
 --[=[
-	Returns whether the document is open or not
+	Returns whether the document is open or not.
 
 	@return boolean
 ]=]
 function Document.IsOpen<T>(self: Document<T>): boolean
 	return self._open
+end
+
+--[=[
+	Yields the current thread until the document has been opened.
+	Returns true if the document is open, false if the document failed to open.
+
+	@return boolean
+
+	@yields
+]=]
+function Document.AwaitOpen<T>(self: Document<T>): boolean
+	if self._open then
+		return true
+	end
+
+	local thread = coroutine.running()
+	local success = false
+	local done = false
+
+	local function resume()
+		if done or coroutine.status(thread) ~= "suspended" then
+			return
+		end
+		done = true
+		task.defer(thread)
+	end
+
+	local cleanupSuccess, cleanupFail
+
+	cleanupSuccess = self:HookAfter("Open", function()
+		cleanupFail()
+		cleanupSuccess()
+		success = true
+		resume()
+	end)
+
+	cleanupFail = self:HookFail("Open", function()
+		cleanupFail()
+		cleanupSuccess()
+		resume()
+	end)
+
+	coroutine.yield()
+
+	return success
 end
 
 --[=[

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -22,11 +22,6 @@ local function shouldFail(func: (...any) -> ())
 end
 
 local function Test(name, test)
-	-- FIXME remove this
-	if not string.match(name, "AwaitOpen") then
-		return
-	end
-
 	Results.total += 1
 
 	print(`Running test {Results.total}`)

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -22,6 +22,11 @@ local function shouldFail(func: (...any) -> ())
 end
 
 local function Test(name, test)
+	-- FIXME remove this
+	if not string.match(name, "AwaitOpen") then
+		return
+	end
+
 	Results.total += 1
 
 	print(`Running test {Results.total}`)
@@ -393,6 +398,74 @@ Test("Session locking affects IsOpenAvailable correctly", function()
 		assert(result.success == true)
 		assert(result.data == false)
 	end
+end)
+
+Test("AwaitOpen returns true immediately if the document is open", function()
+	local documentStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local openResult = document:Open()
+	assert(openResult.success == true)
+
+	local thread = task.spawn(function()
+		local awaitResult = document:AwaitOpen()
+		assert(awaitResult == true)
+	end)
+
+	assert(coroutine.status(thread) == "dead")
+end)
+
+Test("AwaitOpen returns true once the document has opened", function()
+	local documentStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+
+	local thread = task.spawn(function()
+		local awaitResult = document:AwaitOpen()
+		assert(awaitResult == true)
+	end)
+
+	assert(document:IsOpen() == false)
+	assert(coroutine.status(thread) == "suspended")
+
+	local openResult = document:Open()
+	assert(openResult.success == true)
+
+	local mainThread = coroutine.running()
+	local checkThread = task.defer(function()
+		-- Defer to wait for AwaitOpen to return
+		assert(coroutine.status(thread) == "dead")
+		task.defer(mainThread)
+	end)
+	coroutine.yield()
+	
+	assert(coroutine.status(checkThread) == "dead")
+end)
+
+Test("AwaitOpen returns false if the document fails to open", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+
+	local thread = task.spawn(function()
+		local awaitResult = document:AwaitOpen()
+		assert(awaitResult == false)
+	end)
+
+	assert(document:IsOpen() == false)
+	assert(coroutine.status(thread) == "suspended")
+
+	mockDataStore.errors:addSimulatedErrors(5)
+
+	local openResult = document:Open()
+	assert(openResult.success == false)
+
+	local mainThread = coroutine.running()
+	local checkThread = task.defer(function()
+		-- Defer to wait for AwaitOpen to return
+		assert(coroutine.status(thread) == "dead")
+		task.defer(mainThread)
+	end)
+	coroutine.yield()
+
+	assert(coroutine.status(checkThread) == "dead")
 end)
 
 Test("Session locking prevents other sessions from opening", function()

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anthony0br/documentservice"
 description = "DataStores with full type checking, hooks, +more"
-version = "1.1.3"
+version = "1.2.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
Includes tests for `Document:AwaitOpen`. Increments minor version number.

I decided to keep the page for the waiting guide around for the sake of those who would look for it and find it missing otherwise. Now it just tells the user to find the `Document:AwaitOpen` method in the API.