### PR TITLE
Add action signals, deprecate after hooks (v1.2.0).

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,7 +2,25 @@
 sidebar_position: 8
 ---
 
-# Hooks
+# Signals & Hooks
+
+## Signals
+
+DocumentService provides 5 signals:
+UpdatedSignal, OpenedSignal, ReadSignal, ClosedSignal, CacheChangedSignal.
+
+These signals allow you to wait for a document to be open before modifying it or
+to tap into cache changes (e.g. for replication), for example. They also
+implement the Once and cancellation functionality of after hooks, through `:Once` and `:Disconnect`.
+
+They are implemented with sleitnick signals, so listeners are wrapped in a task.spawn
+and hence will run immediately (and before the method returns), until a yield
+is encountered, and will run in reverse order to the order they are added.
+
+## Hooks
+
+Hooks are now deprecated (except for before hooks, which can be useful
+for debugging/logging). Use signals in new work instead.
 
 To listen to and respond to events, like saving or reading data, DocumentService
 has a hooks API: `HookBefore`, `HookAfter`, `OnceBefore`, and `OnceAfter`.

--- a/docs/waiting.md
+++ b/docs/waiting.md
@@ -4,20 +4,4 @@ sidebar_position: 7
 
 # Waiting for a Document to open
 
-A common question I am asked is how to wait for a document to open (on a different
-thread to the one which called `:Open`)
-This is how I do that currently:
-
-```lua
-local thread = coroutine.running()
-
-if not document:IsOpen() then
-    document:OnceAfter("Open", function()
-        task.defer(thread)
-    end)
-    coroutine.yield()
-end
-```
-
-Warning: this implementation could yield indefinitely. You could use `OnceFail`
-to prevent this.
+Use `document:GetOpenedSignal():Wait()`.

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -653,8 +653,9 @@ function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResu
 end
 
 --[=[
-	Retrieves a signal that is fired when the document is updated. Note that this will
-	be fired on completion of any `:Update`, even if it failed.
+	Retrieves a signal that is fired when the document is updated.
+	For example, this will be fired after an autosave or after you call :`Save()`.
+	Note that this will be fired on completion of any `:Update`, even if it failed.
 	
 	@return Signal<WriteResult<T>>
 

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -628,7 +628,7 @@ end
 
 --[=[
 	Retrieves a signal that is fired when a document is opened. Note that this will
-	be fired on completion of any `:Open`, even if the document failed to update.
+	be fired on completion of any `:Open`, even if it if it failed.
 	
 	@return Signal<OpenResult<T>>
 
@@ -639,10 +639,10 @@ function Document.GetOpenedSignal<T>(self: Document<T>): Signal.Signal<OpenResul
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is opened. Note that this will
-	be fired on completion of any `:Close`, even if the document failed to update.
+	Retrieves a signal that is fired when a document is closed. Note that this will
+	be fired on completion of any `:Close`, even if it failed.
 	
-	@return Signal<OpenResult<T>>
+	@return Signal<WriteResult<T?>
 
 	@yields
 ]=]
@@ -651,10 +651,10 @@ function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResu
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is opened. Note that this will
-	be fired on completion of any `:Update`, even if the document failed to update.
+	Retrieves a signal that is fired when a document is updated. Note that this will
+	be fired on completion of any `:Update`, even if it failed.
 	
-	@return Signal<OpenResult<T>>
+	@return Signal<WriteResult<T>>
 
 	@yields
 ]=]
@@ -663,10 +663,10 @@ function Document.GetUpdatedSignal<T>(self: Document<T>): Signal.Signal<WriteRes
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is opened. Note that this will
-	be fired on completion of any `:Update`, even if the document failed to update.
+	Retrieves a signal that is fired when a document is read. Note that this will
+	be fired on completion of any `:Read`, even if it failed.
 	
-	@return Signal<OpenResult<T>>
+	@return Signal<ReadResult<T>>
 
 	@yields
 ]=]

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -81,6 +81,7 @@ export type Document<T> = typeof(setmetatable(
 			Close: Signal.Signal<any>,
 			Read: Signal.Signal<any>,
 			Update: Signal.Signal<any>,
+			Cache: Signal.Signal<any>,
 		},
 		_migrations: Migrations,
 		_cache: T,
@@ -321,6 +322,7 @@ function Document.new<T>(props: {
 			Close = Signal.new(),
 			Update = Signal.new(),
 			Read = Signal.new(),
+			Cache = Signal.new(),
 		},
 		_migrations = deepFreeze(props.migrations),
 		_isClosing = false,
@@ -627,8 +629,8 @@ function Document.Steal<T>(self: Document<T>)
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is opened. Note that this will
-	be fired on completion of any `:Open`, even if it if it failed.
+	Retrieves a signal that is fired when the document is opened. Note that this will
+	be fired on completion of any `:Open`, even if it failed.
 	
 	@return Signal<OpenResult<T>>
 
@@ -639,7 +641,7 @@ function Document.GetOpenedSignal<T>(self: Document<T>): Signal.Signal<OpenResul
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is closed. Note that this will
+	Retrieves a signal that is fired when the document is closed. Note that this will
 	be fired on completion of any `:Close`, even if it failed.
 	
 	@return Signal<WriteResult<T?>
@@ -651,7 +653,7 @@ function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResu
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is updated. Note that this will
+	Retrieves a signal that is fired when the document is updated. Note that this will
 	be fired on completion of any `:Update`, even if it failed.
 	
 	@return Signal<WriteResult<T>>
@@ -663,7 +665,7 @@ function Document.GetUpdatedSignal<T>(self: Document<T>): Signal.Signal<WriteRes
 end
 
 --[=[
-	Retrieves a signal that is fired when a document is read. Note that this will
+	Retrieves a signal that is fired when the document is read. Note that this will
 	be fired on completion of any `:Read`, even if it failed.
 	
 	@return Signal<ReadResult<T>>
@@ -672,6 +674,17 @@ end
 ]=]
 function Document.GetReadSignal<T>(self: Document<T>): Signal.Signal<ReadResult<T>>
 	return self._actionSignals.Read
+end
+
+--[=[
+	Retrieves a signal that is fired when the document's cache is set.
+	
+	@return Signal<T>
+
+	@yields
+]=]
+function Document.GetCacheChangedSignal<T>(self: Document<T>): Signal.Signal<T>
+	return self._actionSignals.Cache
 end
 
 --[=[
@@ -839,6 +852,8 @@ function Document.SetCache<T>(self: Document<T>, newCache: T): T
 	assert(self._lockSessions, "Cache is only supported for session locked data")
 
 	self._cache = deepFreeze(newCache)
+
+	self._actionSignals.Cache:Fire(newCache)
 
 	return self._cache
 end

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -486,19 +486,19 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 
 	local failResult: OpenResult<T>?
 
-	-- We need to check this first, since updateOk will be false in
+	if not updateOk then
+		failResult = {
+			success = false,
+			reason = "RobloxAPIError",
+		}
+	end
+
+	-- We need to check this after updateOk, since updateOk will be false in
 	-- the case of a SessionLockedError
 	if lockedByOther then
 		failResult = {
 			success = false,
 			reason = "SessionLockedError",
-		}
-	end
-
-	if not updateOk then
-		failResult = {
-			success = false,
-			reason = "RobloxAPIError",
 		}
 	end
 
@@ -509,14 +509,14 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 		}
 	end
 
+	-- If there are multiple problems, this is the highest priority one so
+	-- overwrites the others.
 	if failedCheck then
 		failResult = {
 			success = false,
 			reason = "CheckError",
 		}
 	end
-
-	print(failResult)
 
 	if failResult then
 		runHooks(self._failHooks.Open)

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -1221,6 +1221,8 @@ end
 --[=[
 	Attaches a hook which occurs after the event, before the method returns.
 
+	@deprecated v1.2.0 -- use signals
+
 	Note that if a hook yields, it will yield all methods that call it. Hooks
 	are called in the order they are added.
 
@@ -1243,7 +1245,7 @@ end
 --[=[
 	Attaches a hook which occurs after an event fails.
 
-	@deprecated
+	@deprecated v1.2.0 -- use signals
 
 	Note that fail hooks only run when a method returns an Err<E> type. They
 	will not run if the method throws a Luau error due to incorrect usage.
@@ -1264,8 +1266,6 @@ end
 --[=[
 	Attaches a single-use hook which occurs before the event.
 
-	@deprecated
-
 	@param event -- the operation to call the hook before
 	@param hook -- a hook function that receives the arguments passed in to the operation
 ]=]
@@ -1281,7 +1281,7 @@ end
 --[=[
 	Attaches a single-use hook which occurs after the event, before the method returns.
 
-	@deprecated
+	@deprecated v1.2.0 -- use signals
 
 	@param event -- the operation to call the hook after
 	@param hook -- a hook function that receives the arguments passed in to the operation
@@ -1298,7 +1298,7 @@ end
 --[=[
 	Attaches a single-use hook which occurs after an event fails.
 
-	@deprecated
+	@deprecated v1.2.0 -- use signals
 
 	@param event -- the operation to call the hook after
 	@param hook -- a hook function that receives the arguments passed in to the operation

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -5,6 +5,7 @@
 local Types = require("./Types")
 local SaveUtil = require("./SaveUtil")
 local deepFreeze = require("./DeepFreeze")
+local Signal = require("./Signal")
 
 local SESSION_EXPIRE_TIME = 600
 local AUTOSAVE_INTERVAL = 150
@@ -61,6 +62,7 @@ export type Document<T> = typeof(setmetatable(
 			Read: { () -> () },
 			Update: { () -> () },
 		},
+		-- Post & fail hooks are deprectaed.
 		_postHooks: {
 			Open: { () -> () },
 			Close: { () -> () },
@@ -72,6 +74,13 @@ export type Document<T> = typeof(setmetatable(
 			Close: { () -> () },
 			Read: { () -> () },
 			Update: { () -> () },
+		},
+		-- We get a recursive type error if we use Signal.Signal<OpenResult<T>> etc
+		_actionSignals: {
+			Open: Signal.Signal<any>,
+			Close: Signal.Signal<any>,
+			Read: Signal.Signal<any>,
+			Update: Signal.Signal<any>,
 		},
 		_migrations: Migrations,
 		_cache: T,
@@ -105,6 +114,8 @@ type OpenResult<T> = Result<T, RobloxAPIError | BackwardsCompatibilityError | Ch
 	@within Document
 ]=]
 type WriteResult<T> = Result<T, RobloxAPIError | SessionLockedError | SchemaError>
+
+type ReadResult<T> = Result<T, RobloxAPIError | SchemaError | CheckError | BackwardsCompatibilityError>
 
 type KeyData<T> = {
 	documentServiceSchemaVersion: number,
@@ -305,6 +316,12 @@ function Document.new<T>(props: {
 			Update = {},
 			Read = {},
 		},
+		_actionSignals = {
+			Open = Signal.new(),
+			Close = Signal.new(),
+			Update = Signal.new(),
+			Read = Signal.new(),
+		},
 		_migrations = deepFreeze(props.migrations),
 		_isClosing = false,
 		_cache = props.default,
@@ -457,7 +474,7 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 			documentServiceSchemaVersion = INTERNAL_SCHEMA_VERSION,
 			sessionLockId = self._sessionId,
 			lockTimestamp = os.time(),
-			isLocked = if self._lockSessions then true else false,
+			isLocked = self._lockSessions,
 			-- If we are in an old server and the data is of a future version
 			-- that is backwards compatible, keep the version number so that
 			-- migrations do not run more than once
@@ -467,42 +484,46 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 		}
 	end, self._dataStore, self._key)
 
+	local failResult: OpenResult<T>?
+
 	-- We need to check this first, since updateOk will be false in
 	-- the case of a SessionLockedError
 	if lockedByOther then
-		runHooks(self._failHooks.Open)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "SessionLockedError",
 		}
 	end
 
 	if not updateOk then
-		runHooks(self._failHooks.Open)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "RobloxAPIError",
 		}
 	end
 
 	if incompatibleVersion then
-		runHooks(self._failHooks.Open)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "BackwardsCompatibilityError",
 		}
 	end
 
 	if failedCheck then
-		runHooks(self._failHooks.Open)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "CheckError",
 		}
+	end
+
+	print(failResult)
+
+	if failResult then
+		runHooks(self._failHooks.Open)
+
+		self._actionSignals.Open:Fire(failResult)
+
+		return failResult
 	end
 
 	if transformInvalid then
@@ -534,10 +555,14 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 
 	runHooks(self._postHooks.Open)
 
-	return {
+	local result: OpenResult<T> = {
 		success = true,
 		data = (updatedKeyData :: KeyData<T>).data,
 	}
+
+	self._actionSignals.Open:Fire(result)
+
+	return result
 end
 
 --[=[
@@ -547,7 +572,7 @@ end
 
 	Will throw a Luau error if the transform produces invalid or unsavable data.
 
-	Runs both Open and Update hooks, including fail hooks.
+	Runs both Open and Update hooks and signals, including fail hooks.
 
 	@return OpenResult<T>
 
@@ -564,6 +589,8 @@ function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): 
 	local result = self:Open()
 
 	self._onOpenTransform = nil
+
+	self._actionSignals.Update:Fire(result)
 
 	if result.success then
 		runHooks(self._postHooks.Update)
@@ -600,8 +627,59 @@ function Document.Steal<T>(self: Document<T>)
 end
 
 --[=[
-	Returns a false Result if Document is currently open, locked by another
-	session, otherwise returns a true Result.
+	Retrieves a signal that is fired when a document is opened. Note that this will
+	be fired on completion of any `:Open`, even if the document failed to update.
+	
+	@return Signal<OpenResult<T>>
+
+	@yields
+]=]
+function Document.GetOpenedSignal<T>(self: Document<T>): Signal.Signal<OpenResult<T>>
+	return self._actionSignals.Open
+end
+
+--[=[
+	Retrieves a signal that is fired when a document is opened. Note that this will
+	be fired on completion of any `:Close`, even if the document failed to update.
+	
+	@return Signal<OpenResult<T>>
+
+	@yields
+]=]
+function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T?>>
+	return self._actionSignals.Close
+end
+
+--[=[
+	Retrieves a signal that is fired when a document is opened. Note that this will
+	be fired on completion of any `:Update`, even if the document failed to update.
+	
+	@return Signal<OpenResult<T>>
+
+	@yields
+]=]
+function Document.GetUpdatedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T>>
+	return self._actionSignals.Update
+end
+
+--[=[
+	Retrieves a signal that is fired when a document is opened. Note that this will
+	be fired on completion of any `:Update`, even if the document failed to update.
+	
+	@return Signal<OpenResult<T>>
+
+	@yields
+]=]
+function Document.GetReadSignal<T>(self: Document<T>): Signal.Signal<ReadResult<T>>
+	return self._actionSignals.Read
+end
+
+--[=[
+	Returns a false Result if Document is either:
+	i. Currently open in this server
+	ii. Currently locked by another session
+	
+	Otherwise returns a true Result.
 
 	If props.lockSessions is false, this will always return a true Result.
 
@@ -677,6 +755,8 @@ end
 	If session locked, will save the document, remove the lock, and
 	cancel autosaves first. If this fails, the document will not be closed.
 
+	If the Close performs a Save, Result.data will be the data saved.
+
 	@return WriteResult<T?>
 
 	@yields
@@ -689,17 +769,19 @@ function Document.Close<T>(self: Document<T>): WriteResult<T?>
 	-- This causes :Save to also remove the session lock
 	self._isClosing = true
 
-	local result: WriteResult<T>
+	local saveResult: WriteResult<T>
 
 	if self._lockSessions then
-		result = self:Save()
+		saveResult = self:Save()
 
-		if not result.success then
+		-- Abort the closure if the save failed
+		if not saveResult.success then
 			self._isClosing = false
 
 			runHooks(self._failHooks.Close)
+			self._actionSignals.Close:Fire(saveResult)
 
-			return result
+			return saveResult
 		end
 	end
 
@@ -712,11 +794,18 @@ function Document.Close<T>(self: Document<T>): WriteResult<T?>
 
 	runHooks(self._postHooks.Close)
 
-	return if result
-		then result
-		else {
-			success = true,
-		}
+	local result: WriteResult<T?> = {
+		success = true,
+	}
+
+	-- If we saved then return the data saved in the result
+	if self._lockSessions then
+		result = saveResult
+	end
+
+	self._actionSignals.Close:Fire(result)
+
+	return result
 end
 
 --[=[
@@ -901,31 +990,35 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 		error("Not storable: " .. notStorableErr)
 	end
 
-	if not success then
-		runHooks(self._failHooks.Update)
+	local failResult: WriteResult<T>?
 
-		return {
+	if not success then
+		failResult = {
 			success = false,
 			reason = "RobloxAPIError",
 		}
 	end
 
 	if lockedByOther then
-		runHooks(self._failHooks.Update)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "SessionLockedError",
 		}
 	end
 
 	if schemaError then
-		runHooks(self._failHooks.Update)
-
-		return {
+		failResult = {
 			success = false,
 			reason = "SchemaError",
 		}
+	end
+
+	if failResult then
+		runHooks(self._failHooks.Update)
+
+		self._actionSignals.Update:Fire(failResult)
+
+		return failResult
 	end
 
 	-- Cast to KeyData<T> since the new data has already passed self._check and
@@ -938,10 +1031,14 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 
 	runHooks(self._postHooks.Update)
 
-	return {
+	local result: WriteResult<T> = {
 		success = true,
 		data = updatedData,
 	}
+
+	self._actionSignals.Update:Fire(result)
+
+	return result
 end
 
 --[=[
@@ -1013,29 +1110,37 @@ end
 
 	@yields
 ]=]
-function Document.Read<T>(
-	self: Document<T>
-): Result<T, RobloxAPIError | SchemaError | CheckError | BackwardsCompatibilityError>
+function Document.Read<T>(self: Document<T>): ReadResult<T>
 	runHooks(self._preHooks.Read)
 
 	local success, getValue: any = SaveUtil.getAsync(self._dataStore, self._key)
 
 	if not success then
 		runHooks(self._failHooks.Read)
-		return {
+
+		local result: ReadResult<T> = {
 			success = false,
 			reason = "RobloxAPIError",
 		}
+
+		self._actionSignals.Read:Fire(result)
+
+		return result
 	end
 
 	local keyData = checkKeyData(getValue)
 
 	if not keyData then
 		runHooks(self._failHooks.Read)
-		return {
+
+		local result: ReadResult<T> = {
 			success = false,
 			reason = "SchemaError",
 		}
+
+		self._actionSignals.Read:Fire(result)
+
+		return result
 	end
 
 	local migratedData = runMigrations(self._migrations, keyData.data, keyData.dataSchemaVersion)
@@ -1044,28 +1149,42 @@ function Document.Read<T>(
 
 	if not checkOk then
 		runHooks(self._failHooks.Read)
-		return {
+
+		local result: ReadResult<T> = {
 			success = false,
 			reason = "CheckError",
 		}
+
+		self._actionSignals.Read:Fire(result)
+
+		return result
 	end
 
 	local data = migratedData :: T
 
 	if #self._migrations < keyData.lastCompatibleVersion then
 		runHooks(self._failHooks.Read)
-		return {
+
+		local result: ReadResult<T> = {
 			success = false,
 			reason = "BackwardsCompatibilityError",
 		}
+
+		self._actionSignals.Read:Fire(result)
+
+		return result
 	end
 
 	runHooks(self._postHooks.Read)
 
-	return {
+	local result: ReadResult<T> = {
 		success = true,
 		data = data,
 	}
+
+	self._actionSignals.Read:Fire(result)
+
+	return result
 end
 
 local function cleanupHook(hooks: { () -> () }, hook: () -> ())
@@ -1124,6 +1243,8 @@ end
 --[=[
 	Attaches a hook which occurs after an event fails.
 
+	@deprecated
+
 	Note that fail hooks only run when a method returns an Err<E> type. They
 	will not run if the method throws a Luau error due to incorrect usage.
 
@@ -1143,6 +1264,8 @@ end
 --[=[
 	Attaches a single-use hook which occurs before the event.
 
+	@deprecated
+
 	@param event -- the operation to call the hook before
 	@param hook -- a hook function that receives the arguments passed in to the operation
 ]=]
@@ -1158,6 +1281,8 @@ end
 --[=[
 	Attaches a single-use hook which occurs after the event, before the method returns.
 
+	@deprecated
+
 	@param event -- the operation to call the hook after
 	@param hook -- a hook function that receives the arguments passed in to the operation
 ]=]
@@ -1172,6 +1297,8 @@ end
 
 --[=[
 	Attaches a single-use hook which occurs after an event fails.
+
+	@deprecated
 
 	@param event -- the operation to call the hook after
 	@param hook -- a hook function that receives the arguments passed in to the operation

--- a/src/DocumentStore.luau
+++ b/src/DocumentStore.luau
@@ -28,7 +28,7 @@ export type DocumentStoreProps<T> = {
 	dataStore: DataStoreInterface,
 	check: (unknown) -> (boolean, T),
 	default: T & {},
-	migrations: Migrations,
+	migrations: Migrations?,
 	lockSessions: boolean,
 	bindToClose: boolean?,
 }
@@ -87,7 +87,7 @@ function DocumentStore.new<T>(props: DocumentStoreProps<T>): DocumentStore<T>
 		_dataStore = props.dataStore,
 		_check = props.check,
 		_default = deepFreeze(props.default),
-		_migrations = deepFreeze(props.migrations),
+		_migrations = deepFreeze(props.migrations or {}),
 		_documents = setmetatable({}, { __mode = "v" }),
 		_lockSessions = props.lockSessions,
 		_openingDocuments = 0,

--- a/src/Retry.luau
+++ b/src/Retry.luau
@@ -24,10 +24,13 @@ local function Retry<T...>(
 
 	for i = 1, maxAttempts do
 		result = { pcall(func, ...) }
+
 		if result[1] == true then
 			break
 		end
+
 		warn(`[Retry] Attempt {i} failed: {result[2]} {debug.traceback("\nat", 1)}`)
+
 		if i < maxAttempts then
 			task.wait(initialWait * (2 ^ (i - 1)))
 		end

--- a/src/SaveUtil.luau
+++ b/src/SaveUtil.luau
@@ -180,7 +180,13 @@ function SaveUtil.updateAsync<T>(
 		assert(SaveUtil.getUpdateBudget() > 0, "Ran out of budget")
 
 		local resultData, resultKeyInfo = dataStore:UpdateAsync(key, function(data: any, keyInfo: DataStoreKeyInfo)
-			return transform(abortAttempt, data, keyInfo)
+			local transformResult = transform(abortAttempt, data, keyInfo)
+
+			if shouldAbort then
+				return data
+			else
+				return transformResult
+			end
 		end)
 
 		if shouldAbort then

--- a/src/Signal.luau
+++ b/src/Signal.luau
@@ -1,0 +1,423 @@
+-- -----------------------------------------------------------------------------
+--               Batched Yield-Safe Signal Implementation                     --
+-- This is a Signal class which has effectively identical behavior to a       --
+-- normal RBXScriptSignal, with the only difference being a couple extra      --
+-- stack frames at the bottom of the stack trace when an error is thrown.     --
+-- This implementation caches runner coroutines, so the ability to yield in   --
+-- the signal handlers comes at minimal extra cost over a naive signal        --
+-- implementation that either always or never spawns a thread.                --
+--                                                                            --
+-- License:                                                                   --
+--   Licensed under the MIT license.                                          --
+--                                                                            --
+-- Authors:                                                                   --
+--   stravant - July 31st, 2021 - Created the file.                           --
+--   sleitnick - August 3rd, 2021 - Modified for Knit.                        --
+-- -----------------------------------------------------------------------------
+
+-- Signal types
+export type Connection = {
+	Disconnect: (self: Connection) -> (),
+	Destroy: (self: Connection) -> (),
+	Connected: boolean,
+}
+
+export type Signal<T...> = {
+	Fire: (self: Signal<T...>, T...) -> (),
+	FireDeferred: (self: Signal<T...>, T...) -> (),
+	Connect: (self: Signal<T...>, fn: (T...) -> ()) -> Connection,
+	Once: (self: Signal<T...>, fn: (T...) -> ()) -> Connection,
+	DisconnectAll: (self: Signal<T...>) -> (),
+	GetConnections: (self: Signal<T...>) -> { Connection },
+	Destroy: (self: Signal<T...>) -> (),
+	Wait: (self: Signal<T...>) -> T...,
+}
+
+-- The currently idle thread to run the next handler on
+local freeRunnerThread = nil
+
+-- Function which acquires the currently idle handler runner thread, runs the
+-- function fn on it, and then releases the thread, returning it to being the
+-- currently idle one.
+-- If there was a currently idle runner thread already, that's okay, that old
+-- one will just get thrown and eventually GCed.
+local function acquireRunnerThreadAndCallEventHandler(fn, ...)
+	local acquiredRunnerThread = freeRunnerThread
+	freeRunnerThread = nil
+	fn(...)
+	-- The handler finished running, this runner thread is free again.
+	freeRunnerThread = acquiredRunnerThread
+end
+
+-- Coroutine runner that we create coroutines of. The coroutine can be
+-- repeatedly resumed with functions to run followed by the argument to run
+-- them with.
+local function runEventHandlerInFreeThread(...)
+	acquireRunnerThreadAndCallEventHandler(...)
+	while true do
+		acquireRunnerThreadAndCallEventHandler(coroutine.yield())
+	end
+end
+
+--[=[
+	@within Signal
+	@interface SignalConnection
+	.Connected boolean
+	.Disconnect (SignalConnection) -> ()
+
+	Represents a connection to a signal.
+	```lua
+	local connection = signal:Connect(function() end)
+	print(connection.Connected) --> true
+	connection:Disconnect()
+	print(connection.Connected) --> false
+	```
+]=]
+
+-- Connection class
+local Connection = {}
+Connection.__index = Connection
+
+function Connection:Disconnect()
+	if not self.Connected then
+		return
+	end
+	self.Connected = false
+
+	-- Unhook the node, but DON'T clear it. That way any fire calls that are
+	-- currently sitting on this node will be able to iterate forwards off of
+	-- it, but any subsequent fire calls will not hit it, and it will be GCed
+	-- when no more fire calls are sitting on it.
+	if self._signal._handlerListHead == self then
+		self._signal._handlerListHead = self._next
+	else
+		local prev = self._signal._handlerListHead
+		while prev and prev._next ~= self do
+			prev = prev._next
+		end
+		if prev then
+			prev._next = self._next
+		end
+	end
+end
+
+Connection.Destroy = Connection.Disconnect
+
+-- Make Connection strict
+setmetatable(Connection, {
+	__index = function(_tb, key)
+		error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+	__newindex = function(_tb, key, _value)
+		error(("Attempt to set Connection::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+})
+
+--[=[
+	@within Signal
+	@type ConnectionFn (...any) -> ()
+
+	A function connected to a signal.
+]=]
+
+--[=[
+	@class Signal
+
+	Signals allow events to be dispatched and handled.
+
+	For example:
+	```lua
+	local signal = Signal.new()
+
+	signal:Connect(function(msg)
+		print("Got message:", msg)
+	end)
+
+	signal:Fire("Hello world!")
+	```
+]=]
+local Signal = {}
+Signal.__index = Signal
+
+--[=[
+	Constructs a new Signal
+
+	@return Signal
+]=]
+function Signal.new<T...>(): Signal<T...>
+	local self = setmetatable({
+		_handlerListHead = false,
+		_proxyHandler = nil,
+		_yieldedThreads = nil,
+	}, Signal)
+
+	return self
+end
+
+--[=[
+	Constructs a new Signal that wraps around an RBXScriptSignal.
+
+	@param rbxScriptSignal RBXScriptSignal -- Existing RBXScriptSignal to wrap
+	@return Signal
+
+	For example:
+	```lua
+	local signal = Signal.Wrap(workspace.ChildAdded)
+	signal:Connect(function(part) print(part.Name .. " added") end)
+	Instance.new("Part").Parent = workspace
+	```
+]=]
+function Signal.Wrap<T...>(rbxScriptSignal: RBXScriptSignal): Signal<T...>
+	assert(
+		typeof(rbxScriptSignal) == "RBXScriptSignal",
+		"Argument #1 to Signal.Wrap must be a RBXScriptSignal; got " .. typeof(rbxScriptSignal)
+	)
+
+	local signal = Signal.new()
+	signal._proxyHandler = rbxScriptSignal:Connect(function(...)
+		signal:Fire(...)
+	end)
+
+	return signal
+end
+
+--[=[
+	Checks if the given object is a Signal.
+
+	@param obj any -- Object to check
+	@return boolean -- `true` if the object is a Signal.
+]=]
+function Signal.Is(obj: any): boolean
+	return type(obj) == "table" and getmetatable(obj) == Signal
+end
+
+--[=[
+	@param fn ConnectionFn
+	@return SignalConnection
+
+	Connects a function to the signal, which will be called anytime the signal is fired.
+	```lua
+	signal:Connect(function(msg, num)
+		print(msg, num)
+	end)
+
+	signal:Fire("Hello", 25)
+	```
+]=]
+function Signal:Connect(fn)
+	local connection = setmetatable({
+		Connected = true,
+		_signal = self,
+		_fn = fn,
+		_next = false,
+	}, Connection)
+
+	if self._handlerListHead then
+		connection._next = self._handlerListHead
+		self._handlerListHead = connection
+	else
+		self._handlerListHead = connection
+	end
+
+	return connection
+end
+
+--[=[
+	@deprecated v1.3.0 -- Use `Signal:Once` instead.
+	@param fn ConnectionFn
+	@return SignalConnection
+]=]
+function Signal:ConnectOnce(fn)
+	return self:Once(fn)
+end
+
+--[=[
+	@param fn ConnectionFn
+	@return SignalConnection
+
+	Connects a function to the signal, which will be called the next time the signal fires. Once
+	the connection is triggered, it will disconnect itself.
+	```lua
+	signal:Once(function(msg, num)
+		print(msg, num)
+	end)
+
+	signal:Fire("Hello", 25)
+	signal:Fire("This message will not go through", 10)
+	```
+]=]
+function Signal:Once(fn)
+	local connection
+	local done = false
+
+	connection = self:Connect(function(...)
+		if done then
+			return
+		end
+
+		done = true
+		connection:Disconnect()
+		fn(...)
+	end)
+
+	return connection
+end
+
+function Signal:GetConnections()
+	local items = {}
+
+	local item = self._handlerListHead
+	while item do
+		table.insert(items, item)
+		item = item._next
+	end
+
+	return items
+end
+
+-- Disconnect all handlers. Since we use a linked list it suffices to clear the
+-- reference to the head handler.
+--[=[
+	Disconnects all connections from the signal.
+	```lua
+	signal:DisconnectAll()
+	```
+]=]
+function Signal:DisconnectAll()
+	local item = self._handlerListHead
+	while item do
+		item.Connected = false
+		item = item._next
+	end
+	self._handlerListHead = false
+
+	local yieldedThreads = rawget(self, "_yieldedThreads")
+	if yieldedThreads then
+		for thread in yieldedThreads do
+			if coroutine.status(thread) == "suspended" then
+				warn(debug.traceback(thread, "signal disconnected; yielded thread cancelled", 2))
+				task.cancel(thread)
+			end
+		end
+		table.clear(self._yieldedThreads)
+	end
+end
+
+-- Signal:Fire(...) implemented by running the handler functions on the
+-- coRunnerThread, and any time the resulting thread yielded without returning
+-- to us, that means that it yielded to the Roblox scheduler and has been taken
+-- over by Roblox scheduling, meaning we have to make a new coroutine runner.
+--[=[
+	@param ... any
+
+	Fire the signal, which will call all of the connected functions with the given arguments.
+	```lua
+	signal:Fire("Hello")
+
+	-- Any number of arguments can be fired:
+	signal:Fire("Hello", 32, {Test = "Test"}, true)
+	```
+]=]
+function Signal:Fire(...)
+	local item = self._handlerListHead
+	while item do
+		if item.Connected then
+			if not freeRunnerThread then
+				freeRunnerThread = coroutine.create(runEventHandlerInFreeThread)
+			end
+			task.spawn(freeRunnerThread, item._fn, ...)
+		end
+		item = item._next
+	end
+end
+
+--[=[
+	@param ... any
+
+	Same as `Fire`, but uses `task.defer` internally & doesn't take advantage of thread reuse.
+	```lua
+	signal:FireDeferred("Hello")
+	```
+]=]
+function Signal:FireDeferred(...)
+	local item = self._handlerListHead
+	while item do
+		local conn = item
+		task.defer(function(...)
+			if conn.Connected then
+				conn._fn(...)
+			end
+		end, ...)
+		item = item._next
+	end
+end
+
+--[=[
+	@return ... any
+	@yields
+
+	Yields the current thread until the signal is fired, and returns the arguments fired from the signal.
+	Yielding the current thread is not always desirable. If the desire is to only capture the next event
+	fired, using `Once` might be a better solution.
+	```lua
+	task.spawn(function()
+		local msg, num = signal:Wait()
+		print(msg, num) --> "Hello", 32
+	end)
+	signal:Fire("Hello", 32)
+	```
+]=]
+function Signal:Wait()
+	local yieldedThreads = rawget(self, "_yieldedThreads")
+	if not yieldedThreads then
+		yieldedThreads = {}
+		rawset(self, "_yieldedThreads", yieldedThreads)
+	end
+
+	local thread = coroutine.running()
+	yieldedThreads[thread] = true
+
+	self:Once(function(...)
+		yieldedThreads[thread] = nil
+		task.spawn(thread, ...)
+	end)
+
+	return coroutine.yield()
+end
+
+--[=[
+	Cleans up the signal.
+
+	Technically, this is only necessary if the signal is created using
+	`Signal.Wrap`. Connections should be properly GC'd once the signal
+	is no longer referenced anywhere. However, it is still good practice
+	to include ways to strictly clean up resources. Calling `Destroy`
+	on a signal will also disconnect all connections immediately.
+	```lua
+	signal:Destroy()
+	```
+]=]
+function Signal:Destroy()
+	self:DisconnectAll()
+
+	local proxyHandler = rawget(self, "_proxyHandler")
+	if proxyHandler then
+		proxyHandler:Disconnect()
+	end
+end
+
+-- Make signal strict
+setmetatable(Signal, {
+	__index = function(_tb, key)
+		error(("Attempt to get Signal::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+	__newindex = function(_tb, key, _value)
+		error(("Attempt to set Signal::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+})
+
+return table.freeze({
+	new = Signal.new,
+	Wrap = Signal.Wrap,
+	Is = Signal.Is,
+})

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -2288,6 +2288,127 @@ Test("Read Hooks run correctly", function()
 	document:Close()
 end)
 
+-- Sleitnick Signal is well-established and tested, so we do not need
+-- to test Once functionality etc
+Test("Read signals fire correctly", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local secondRan = false
+	local failRan = false
+
+	document:GetReadSignal():Connect(function(result)
+		if result.success then
+			secondRan = true
+		else
+			failRan = true
+		end
+	end)
+
+	-- Open the document first so we don't get SchemaError
+	local result = document:Open()
+	local resultRead = document:Read()
+	assert(resultRead.success, "Read failed")
+	assert(secondRan, "Success signal didn't run")
+	assert(result.success, "Open failed")
+
+	assert(not failRan)
+	mockDataStore.errors:addSimulatedErrors(5)
+	resultRead = document:Read()
+	assert(not resultRead.success, "Read succeeded")
+	assert(failRan)
+
+	document:Close()
+end)
+
+-- This test relies on the fact that `:Save` calls Update
+-- to avoid very repetitive unit tests
+Test("Update signals fire correctly", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local secondRan = false
+	local failRan = false
+
+	document:GetUpdatedSignal():Connect(function(result)
+		if result.success then
+			secondRan = true
+		else
+			failRan = true
+		end
+	end)
+
+	-- Open the document first so we don't get SchemaError
+	local result = document:Open()
+	local saveResult = document:Save()
+	assert(saveResult.success, "Save failed")
+	assert(secondRan, "Success signal didn't run")
+	assert(result.success, "Open failed")
+
+	assert(not failRan)
+	mockDataStore.errors:addSimulatedErrors(5)
+	saveResult = document:Save()
+	assert(not saveResult.success, "Save succeeded")
+	assert(failRan)
+
+	document:Close()
+end)
+
+Test("Closed signals fire correctly", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local secondRan = false
+	local failRan = false
+
+	document:GetClosedSignal():Connect(function(result)
+		if result.success then
+			secondRan = true
+		else
+			failRan = true
+		end
+	end)
+
+	-- Open the document first so we don't get SchemaError
+	local result = document:Open()
+	local closeResult = document:Close()
+	assert(closeResult.success, "Close failed")
+	assert(secondRan, "Success signal didn't run")
+	assert(result.success, "Open failed")
+
+	assert(not failRan)
+	document:Open()
+	mockDataStore.errors:addSimulatedErrors(5)
+	closeResult = document:Close()
+	assert(not closeResult.success, "Close succeeded")
+	assert(failRan)
+
+	document:Close()
+end)
+
+Test("Open signals fire correctly", function()
+	local documentStore, mockDataStore = createTestDocumentStore()
+	local document = documentStore:GetDocument("1")
+	local secondRan = false
+	local failRan = false
+
+	document:GetOpenedSignal():Connect(function(result)
+		if result.success then
+			secondRan = true
+		else
+			failRan = true
+		end
+	end)
+
+	local result = document:Open()
+	assert(secondRan, "Hook didn't run")
+	assert(result.success, "Open failed")
+	document:Close()
+
+	assert(not failRan)
+	mockDataStore.errors:addSimulatedErrors(5)
+	local openResult = document:Open()
+	assert(not openResult.success, "Open succeeded")
+	assert(failRan)
+end)
+
 Test("Read Hooks run even if cleaned up while executing hooks", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
@@ -2518,7 +2639,7 @@ Test("Fail Update Hooks run correctly", function()
 	document:Close()
 end)
 
-Test("Read Hooks run correctly", function()
+Test("Read Once Hooks run correctly", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 	local firstRan = false
@@ -2558,14 +2679,6 @@ Test("Read Hooks run correctly", function()
 
 	document:Close()
 end)
-
--- Test("Opened signal fires in all cases")
-
--- Test("Closed signal fires in all cases")
-
--- Test("Updated signal fires in all cases")
-
--- Test("Read signal fires in all cases")
 
 Test("Open documents are not garbage collected", function()
 	local documentStore = createTestDocumentStore()

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -395,42 +395,6 @@ Test("Session locking affects IsOpenAvailable correctly", function()
 	end
 end)
 
-Test("Session locking prevents other sessions from opening", function()
-	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
-
-	local session1 = DocumentService.DocumentStore.new({
-		dataStore = mockDataStore,
-		check = Guard.Check(testDataCheck),
-		default = {
-			Document = "Document",
-			Service = 3,
-		},
-		migrations = {},
-		lockSessions = true,
-	})
-	local session2 = DocumentService.DocumentStore.new({
-		dataStore = mockDataStore,
-		check = Guard.Check(testDataCheck),
-		default = {
-			Document = "Document",
-			Service = 3,
-		},
-		migrations = {},
-		lockSessions = true,
-	})
-	do
-		local document = session1:GetDocument("1")
-		local result = document:Open()
-		assert(result.success == true)
-	end
-	do
-		local document = session2:GetDocument("1")
-		local result = document:Open()
-		assert(result.success == false)
-		assert(result.reason == "SessionLockedError")
-	end
-end)
-
 Test("Data mutations with :Update persist with no migrations", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("6")
@@ -1575,6 +1539,7 @@ Test("Opening a locked document returns SessionLockedError", function()
 		migrations = {},
 		lockSessions = true,
 	})
+
 	local session2 = DocumentService.DocumentStore.new({
 		dataStore = mockDataStore,
 		check = Guard.Check(testDataCheck),
@@ -2258,16 +2223,13 @@ Test("Read Hooks cleanup run correctly", function()
 	local secondCleanupRan = false
 	local failRan = false
 
-	local cleanupFirst = document:HookBefore("Read", function()
-
-	end)
+	local cleanupFirst = document:HookBefore("Read", function() end)
 	firstCleanupRan = pcall(cleanupFirst)
 
 	local cleanupSecond = document:HookAfter("Read", function()
 		assert(firstCleanupRan, "Before hook didn't run")
 	end)
 	secondCleanupRan = pcall(cleanupSecond)
-
 
 	local cleanup
 	cleanup = document:HookFail("Read", function()
@@ -2596,6 +2558,14 @@ Test("Read Hooks run correctly", function()
 
 	document:Close()
 end)
+
+-- Test("Opened signal fires in all cases")
+
+-- Test("Closed signal fires in all cases")
+
+-- Test("Updated signal fires in all cases")
+
+-- Test("Read signal fires in all cases")
 
 Test("Open documents are not garbage collected", function()
 	local documentStore = createTestDocumentStore()

--- a/wally.lock
+++ b/wally.lock
@@ -4,5 +4,5 @@ registry = "test"
 
 [[package]]
 name = "anthony0br/documentservice"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anthony0br/documentservice"
 description = "DataStores with full type checking, hooks, +more"
-version = "1.1.3"
+version = "1.2.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
Closes #83, #75.

- Introduces 4 new getter methods to retrieve signals that are fired on completion of the following actions: Open, Close, Read, Update.
- Signals have better types and pass their result, allowing you to improve error handling and removing the need to handle discrete cases for failures and passes (this was a poor API choice originally).
- Provides additional functionality such as Wait methods, simplifying the process of waiting for events such as waiting for a document to open or waiting for the next update.
- Improves the maintainability of the project since hooks are complex to maintain, and the same Once and cancellation functionality is provided.
- Uses sleitnick signal, which runs listeners in a `task.spawn`, so it is safe to yield in hooks. Any code before a yield will run before the method returns the so you can achieve the same functionality as after hooks.
- Before hooks remain the same as they were before for now but may be changed to signals later.
- Migrations are now optional.

This PR will bring us to release v1.2.0. Awaiting review from other contributors and feedback from library users.