### PR TITLE
chore: fix typo in DataSchema

### DIFF
--- a/docs/creating.md
+++ b/docs/creating.md
@@ -10,7 +10,7 @@ Here's an example of creating one:
 
  ```lua
 type DataSchema = {
-    points: number,
+    coins: number,
 }
 
 local DataInterface = {


### PR DESCRIPTION
The `DataSchema` type previously included an unused `points` field while the actual implementation used `coins`. This change aligns the type definition with the actual data structure being used in `creating.md`, resolving a type mismatch error.