### PR TITLE
refactor: rename yielding methods with async suffix

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -12,4 +12,4 @@ data.Points += points
 document:SetCache(newData)
 ```
 
-For Robux transactions remember to call `Save` to ensure they save!
+For Robux transactions remember to call `SaveAsync` to ensure they save!

--- a/docs/opening.md
+++ b/docs/opening.md
@@ -10,13 +10,13 @@ The following code should run on `Players.PlayerAdded`:
 
  ```lua
 local document = store:GetDocument(tostring(player.UserId))
-local result = document:Open()
+local result = document:OpenAsync()
 
 -- DocumentService retries 5 times over 16 seconds, so it is safe to steal
--- after a failed `:Open`!
+-- after a failed `:OpenAsync`!
 if not result.success and result.reason == "SessionLockedError" then
     document:Steal()
-    result = document:Open()
+    result = document:OpenAsync()
 end
 
 if not result.success then

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -103,9 +103,9 @@ but adding fields is.
 **Use good tools:** Roblox Studio's script editor doesn't provide great linting - luau-lsp is better
 for taking full advantage of type-checking.
 
-**Seperation:** You might want to put your default table, migrations, types and your check function in a separate file to keep things manageable and modular.
+**Separation:** You might want to put your default table, migrations, types and your check function in a separate file to keep things manageable and modular.
 
-**Use cache where you can:** Minimise methods that call DataStore APIs, such as `Read` and `Update`, in
+**Use cache where you can:** Minimise methods that call DataStore APIs, such as `ReadAsync` and `UpdateAsync`, in
 favour of `GetCache` and `SetCache`. This improves performance and reduces the chance of hitting limits.
 
 **Don't change your migrations:** You should never delete a migration. You should not change migrations once they are live (unless you

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -343,7 +343,7 @@ end
 	A document needs to be opened before use (even if it is not session-locked),
 	as this ensures all migrations run and the cases of missing or legacy data
 	are handled. If you only need to update a document once, consider
-	`OpenAndUpdate`.
+	`OpenAndUpdateAsync`.
 
 	Opening a session-locked document will enable periodic autosaves until it is
 	closed.
@@ -367,7 +367,7 @@ end
 
 	@yields
 ]=]
-function Document.Open<T>(self: Document<T>): OpenResult<T>
+function Document.OpenAsync<T>(self: Document<T>): OpenResult<T>
 	assert(not self._open, `{self} already open`)
 	assert(not self._isClosing, `{self} is closing, cannot open`)
 
@@ -575,7 +575,7 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 				return
 			end
 
-			local result = self:Save()
+			local result = self:SaveAsync()
 
 			if not result.success then
 				warn(`[DocumentService] AutoSave for key {self._key} failed due to a {result.reason}`)
@@ -608,7 +608,7 @@ end
 
 	@yields
 ]=]
-function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): OpenResult<T>
+function Document.OpenAndUpdateAsync<T>(self: Document<T>, transform: Transform<T>): OpenResult<T>
 	assert(not self._open, `{self} already open`)
 	assert(not self._isClosing, `{self} is closing, cannot open`)
 
@@ -616,7 +616,7 @@ function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): 
 
 	self._onOpenTransform = transform
 
-	local result = self:Open()
+	local result = self:OpenAsync()
 
 	self._onOpenTransform = nil
 
@@ -634,20 +634,18 @@ function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): 
 end
 
 --[=[
-	Marks the lock as stolen. The next `:Open` call will ignore any existing
+	Marks the lock as stolen. The next `:OpenAsync` call will ignore any existing
 	locks.
 
 	:::info
-	Generally, it is recommended to call `:Steal` and then `:Open` in the case
-	that the initial `:Open` fails due to `SessionLockedError`.
+	Generally, it is recommended to call `:Steal` and then `:OpenAsync` in the case
+	that the initial `:OpenAsync` fails due to `SessionLockedError`.
 	:::
 
 	:::warning
 	Do not use this unless you are very sure the previous session is dead, or
 	you could cause data loss. Only usable on session-locked Documents.
 	:::
-
-	@yields
 ]=]
 function Document.Steal<T>(self: Document<T>)
 	assert(not self._isClosing, "Document is closing")
@@ -658,11 +656,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is opened. Note that this will
-	be fired on completion of any `:Open`, even if it failed.
+	be fired on completion of any `:OpenAsync`, even if it failed.
 	
 	@return Signal<OpenResult<T>>
-
-	@yields
 ]=]
 function Document.GetOpenedSignal<T>(self: Document<T>): Signal.Signal<OpenResult<T>>
 	return self._actionSignals.Open
@@ -670,11 +666,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is closed. Note that this will
-	be fired on completion of any `:Close`, even if it failed.
+	be fired on completion of any `:CloseAsync`, even if it failed.
 	
 	@return Signal<WriteResult<T?>
-
-	@yields
 ]=]
 function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T?>>
 	return self._actionSignals.Close
@@ -682,12 +676,10 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is updated.
-	For example, this will be fired after an autosave or after you call :`Save()`.
-	Note that this will be fired on completion of any `:Update`, even if it failed.
+	For example, this will be fired after an autosave or after you call `:SaveAsync()`.
+	Note that this will be fired on completion of any `:UpdateAsync`, even if it failed.
 	
 	@return Signal<WriteResult<T>>
-
-	@yields
 ]=]
 function Document.GetUpdatedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T>>
 	return self._actionSignals.Update
@@ -695,11 +687,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is read. Note that this will
-	be fired on completion of any `:Read`, even if it failed.
+	be fired on completion of any `:ReadAsync`, even if it failed.
 	
 	@return Signal<ReadResult<T>>
-
-	@yields
 ]=]
 function Document.GetReadSignal<T>(self: Document<T>): Signal.Signal<ReadResult<T>>
 	return self._actionSignals.Read
@@ -709,32 +699,28 @@ end
 	Retrieves a signal that is fired when the document's cache is set.
 	
 	@return Signal<T>
-
-	@yields
 ]=]
 function Document.GetCacheChangedSignal<T>(self: Document<T>): Signal.Signal<T>
 	return self._actionSignals.Cache
 end
 
 --[=[
-	Returns a false Result if Document is either:
-	i. Currently open in this server
-	ii. Currently locked by another session
-	
-	Otherwise returns a true Result.
+	Returns false if the document is either currently open in this server, or
+	currently session-locked by a different server. Otherwise returns true.
 
-	If props.lockSessions is false, this will always return a true Result.
+	If `props.lockSessions` is false, this will always return a true Result since
+	there is no session lock to check.
 
 	:::tip
-	You can use this to check if a player is active to avoid data loss while
-	editing data from another server.
+	You can use this to check if a player is active on another server before
+	attempting to edit their data from this server.
 	:::
 
 	@yields
 
 	@return Result<boolean, RobloxAPIError>
 ]=]
-function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxAPIError>
+function Document.IsAvailableAsync<T>(self: Document<T>): Result<boolean, RobloxAPIError>
 	assert(not self._isClosing, "Document is closing")
 
 	if self._open then
@@ -762,7 +748,7 @@ function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxA
 
 	local keyData = checkKeyData(getValue)
 
-	-- Since the behaviour of Open in this case is to put the existing value
+	-- Since the behaviour of OpenAsync in this case is to put the existing value
 	-- in the key into keyData.data, return a true Result.
 	if not keyData then
 		return {
@@ -781,7 +767,7 @@ function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxA
 end
 
 --[=[
-	Returns whether the document is open or not
+	Returns whether the document is currently open in this server.
 
 	@return boolean
 ]=]
@@ -803,18 +789,18 @@ end
 
 	@yields
 ]=]
-function Document.Close<T>(self: Document<T>): WriteResult<T?>
+function Document.CloseAsync<T>(self: Document<T>): WriteResult<T?>
 	assert(self._open, "Document not open")
 
 	runHooks(self._preHooks.Close)
 
-	-- This causes :Save to also remove the session lock
+	-- This causes :SaveAsync to also remove the session lock
 	self._isClosing = true
 
 	local saveResult: WriteResult<T>
 
 	if self._lockSessions then
-		saveResult = self:Save()
+		saveResult = self:SaveAsync()
 
 		-- Abort the closure if the save failed
 		if not saveResult.success then
@@ -851,7 +837,7 @@ function Document.Close<T>(self: Document<T>): WriteResult<T?>
 end
 
 --[=[
-	Returns true if `:Close` has been called and is incomplete.
+	Returns true if `:CloseAsync` has been called and is incomplete.
 
 	@return boolean
 ]=]
@@ -914,11 +900,11 @@ end
 
 	The document must be open before using this method.
 
-	If using session locking, passing a transform is equvialent to calling
-	`SetCache` with the transformed data and then `Save`.
+	If using session locking, passing a transform is equivalent to calling
+	`SetCache` with the transformed data and then `SaveAsync`.
 	If the Save fails, the cache will still be updated.
 
-	If you only need to update a document once, consider `OpenAndUpdate`.
+	If you only need to update a document once, consider `OpenAndUpdateAsync`.
 
 	Throws if data is not storable or the transform return value is invalid.
 
@@ -934,7 +920,7 @@ end
 
 	:::warning
 	Assumes the data that is already in Data Stores is valid since the last
-	`:Open`. If it isn't, and this is not corrected by the transform, this
+	`:OpenAsync`. If it isn't, and this is not corrected by the transform, this
 	method will throw a luau error.
 	:::
 
@@ -949,7 +935,7 @@ end
 	:::
 
 	:::info
-	Unlike `Open`, this method will not retry if the lock is stolen, and will
+	Unlike `OpenAsync`, this method will not retry if the lock is stolen, and will
 	instead return a `SessionLockedError` after the first attempt.
 	:::
 
@@ -958,7 +944,7 @@ end
 
 	@yields
 ]=]
-function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteResult<T>
+function Document.UpdateAsync<T>(self: Document<T>, transform: Transform<T>): WriteResult<T>
 	assert(self._open, "Document not open")
 
 	runHooks(self._preHooks.Update)
@@ -977,7 +963,7 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 		local updatedData = transform(self._cache)
 		-- Since session locked data requires immutable updates, we can
 		-- get away with just checking references here to avoid running
-		-- SetCache (and firing the signal) for a `:Save` call.
+		-- SetCache (and firing the signal) for a `:SaveAsync` call.
 		if updatedData ~= self._cache then
 			self:SetCache(updatedData)
 		end
@@ -1104,10 +1090,10 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 end
 
 --[=[
-	Saves a Document's cache to its DataStore. Equivalent to calling Update
+	Saves a Document's cache to its DataStore. Equivalent to calling UpdateAsync
 	without transforming the data.
 
-	The document must be open and locked to use this method.
+	The document must be open and session-locked to use this method.
 
 	Returns a WriteResult with the data field being the data saved to Data Stores.
 
@@ -1115,11 +1101,11 @@ end
 
 	@yields
 ]=]
-function Document.Save<T>(self: Document<T>): WriteResult<T>
+function Document.SaveAsync<T>(self: Document<T>): WriteResult<T>
 	assert(self._open, "Document not open")
 	assert(self._lockSessions, "Must be session locked to access cache")
 
-	return self:Update(function(cache)
+	return self:UpdateAsync(function(cache)
 		return cache
 	end)
 end
@@ -1128,7 +1114,7 @@ end
 	Erases all data associated with the key.
 
 	The document must not be open. It is up to you to check if the document
-	is open elsewhere, e.g. via `IsOpenAvailable`.
+	is open elsewhere, e.g. via `IsAvailableAsync`.
 
 	Satisfies compliance with GDPR right of erasure.
 
@@ -1138,7 +1124,7 @@ end
 
 	@yields
 ]=]
-function Document.Erase<T>(self: Document<T>): Result<nil, RobloxAPIError>
+function Document.EraseAsync<T>(self: Document<T>): Result<nil, RobloxAPIError>
 	assert(not self._open, "Cannot erase an open document")
 
 	local success = SaveUtil.removeAsync(self._dataStore, self._key)
@@ -1164,7 +1150,7 @@ end
 
 	:::warning
 	A `SchemaError` will be returned if document has never been opened before,
-	so it is strongly recommended to handle this case, and Open the document
+	so it is strongly recommended to handle this case, and open the document
 	before reading it if possible. This includes when migrating from no library.
 	:::
 
@@ -1174,7 +1160,7 @@ end
 
 	@yields
 ]=]
-function Document.Read<T>(self: Document<T>): ReadResult<T>
+function Document.ReadAsync<T>(self: Document<T>): ReadResult<T>
 	runHooks(self._preHooks.Read)
 
 	local success, getValue: any = SaveUtil.getAsync(self._dataStore, self._key)

--- a/src/DocumentStore.luau
+++ b/src/DocumentStore.luau
@@ -102,7 +102,7 @@ function DocumentStore.new<T>(props: DocumentStoreProps<T>): DocumentStore<T>
 		game:BindToClose(function()
 			gameClosing = true
 
-			self:CloseAllDocuments()
+			self:CloseAllDocumentsAsync()
 		end)
 	end
 
@@ -171,15 +171,15 @@ end
 
 	:::warning
 	Yields until all documents are closed. If there is a systematic error
-	in your :Close, for example a hook errors, this could infinitely yield.
+	in your `:CloseAsync`, for example a hook errors, this could infinitely yield.
 	:::
 
-	Closes documents asynchronously when request budget allows, and yields
+	Closes documents asynchronously when request budget allows, and yields until
 	all open documents are closed.
 
 	@yields
 ]=]
-function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
+function DocumentStore.CloseAllDocumentsAsync<T>(self: DocumentStore<T>)
 	local thread = coroutine.running()
 
 	local complete = self._documentsToClose == 0 and self._openingDocuments == 0
@@ -187,7 +187,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 	-- This while loop exists for two reasons:
 	-- 1. if budget is limited, we can wait for
 	-- more to be available before spawning future threads, so documents
-	-- are closed as quickly as possilbe by minimising retries
+	-- are closed as quickly as possible by minimising retries
 	-- 2. ensures documents that are opening and not yet opened when
 	-- this is called are closed.
 	while not complete do
@@ -210,7 +210,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 
 			task.spawn(function()
 				if v:IsOpen() and not v:IsClosing() then
-					v:Close()
+					v:CloseAsync()
 				end
 
 				if v:IsClosing() then
@@ -219,7 +219,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 					until not v:IsClosing()
 				end
 
-				-- We decrement this even if the .Close failed so the pass
+				-- We decrement this even if the .CloseAsync failed so the pass
 				-- doesn't hang forever
 				documentsToClose -= 1
 

--- a/target/roblox/Document.luau
+++ b/target/roblox/Document.luau
@@ -343,7 +343,7 @@ end
 	A document needs to be opened before use (even if it is not session-locked),
 	as this ensures all migrations run and the cases of missing or legacy data
 	are handled. If you only need to update a document once, consider
-	`OpenAndUpdate`.
+	`OpenAndUpdateAsync`.
 
 	Opening a session-locked document will enable periodic autosaves until it is
 	closed.
@@ -367,7 +367,7 @@ end
 
 	@yields
 ]=]
-function Document.Open<T>(self: Document<T>): OpenResult<T>
+function Document.OpenAsync<T>(self: Document<T>): OpenResult<T>
 	assert(not self._open, `{self} already open`)
 	assert(not self._isClosing, `{self} is closing, cannot open`)
 
@@ -549,9 +549,7 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 	end
 
 	if transformInvalid then
-		error(
-			`Could not open Document {self._key}. Invalid transform function - must return a table that passes the check function.`
-		)
+		error(`Could not open Document {self._key}. Invalid transform function - must return a table that passes the check function.`)
 	end
 
 	if notStorable then
@@ -577,7 +575,7 @@ function Document.Open<T>(self: Document<T>): OpenResult<T>
 				return
 			end
 
-			local result = self:Save()
+			local result = self:SaveAsync()
 
 			if not result.success then
 				warn(`[DocumentService] AutoSave for key {self._key} failed due to a {result.reason}`)
@@ -610,7 +608,7 @@ end
 
 	@yields
 ]=]
-function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): OpenResult<T>
+function Document.OpenAndUpdateAsync<T>(self: Document<T>, transform: Transform<T>): OpenResult<T>
 	assert(not self._open, `{self} already open`)
 	assert(not self._isClosing, `{self} is closing, cannot open`)
 
@@ -618,7 +616,7 @@ function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): 
 
 	self._onOpenTransform = transform
 
-	local result = self:Open()
+	local result = self:OpenAsync()
 
 	self._onOpenTransform = nil
 
@@ -636,20 +634,18 @@ function Document.OpenAndUpdate<T>(self: Document<T>, transform: Transform<T>): 
 end
 
 --[=[
-	Marks the lock as stolen. The next `:Open` call will ignore any existing
+	Marks the lock as stolen. The next `:OpenAsync` call will ignore any existing
 	locks.
 
 	:::info
-	Generally, it is recommended to call `:Steal` and then `:Open` in the case
-	that the initial `:Open` fails due to `SessionLockedError`.
+	Generally, it is recommended to call `:Steal` and then `:OpenAsync` in the case
+	that the initial `:OpenAsync` fails due to `SessionLockedError`.
 	:::
 
 	:::warning
 	Do not use this unless you are very sure the previous session is dead, or
 	you could cause data loss. Only usable on session-locked Documents.
 	:::
-
-	@yields
 ]=]
 function Document.Steal<T>(self: Document<T>)
 	assert(not self._isClosing, "Document is closing")
@@ -660,11 +656,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is opened. Note that this will
-	be fired on completion of any `:Open`, even if it failed.
+	be fired on completion of any `:OpenAsync`, even if it failed.
 	
 	@return Signal<OpenResult<T>>
-
-	@yields
 ]=]
 function Document.GetOpenedSignal<T>(self: Document<T>): Signal.Signal<OpenResult<T>>
 	return self._actionSignals.Open
@@ -672,11 +666,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is closed. Note that this will
-	be fired on completion of any `:Close`, even if it failed.
+	be fired on completion of any `:CloseAsync`, even if it failed.
 	
 	@return Signal<WriteResult<T?>
-
-	@yields
 ]=]
 function Document.GetClosedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T?>>
 	return self._actionSignals.Close
@@ -684,12 +676,10 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is updated.
-	For example, this will be fired after an autosave or after you call :`Save()`.
-	Note that this will be fired on completion of any `:Update`, even if it failed.
+	For example, this will be fired after an autosave or after you call `:SaveAsync()`.
+	Note that this will be fired on completion of any `:UpdateAsync`, even if it failed.
 	
 	@return Signal<WriteResult<T>>
-
-	@yields
 ]=]
 function Document.GetUpdatedSignal<T>(self: Document<T>): Signal.Signal<WriteResult<T>>
 	return self._actionSignals.Update
@@ -697,11 +687,9 @@ end
 
 --[=[
 	Retrieves a signal that is fired when the document is read. Note that this will
-	be fired on completion of any `:Read`, even if it failed.
+	be fired on completion of any `:ReadAsync`, even if it failed.
 	
 	@return Signal<ReadResult<T>>
-
-	@yields
 ]=]
 function Document.GetReadSignal<T>(self: Document<T>): Signal.Signal<ReadResult<T>>
 	return self._actionSignals.Read
@@ -711,32 +699,28 @@ end
 	Retrieves a signal that is fired when the document's cache is set.
 	
 	@return Signal<T>
-
-	@yields
 ]=]
 function Document.GetCacheChangedSignal<T>(self: Document<T>): Signal.Signal<T>
 	return self._actionSignals.Cache
 end
 
 --[=[
-	Returns a false Result if Document is either:
-	i. Currently open in this server
-	ii. Currently locked by another session
-	
-	Otherwise returns a true Result.
+	Returns false if the document is either currently open in this server, or
+	currently session-locked by a different server. Otherwise returns true.
 
-	If props.lockSessions is false, this will always return a true Result.
+	If `props.lockSessions` is false, this will always return a true Result since
+	there is no session lock to check.
 
 	:::tip
-	You can use this to check if a player is active to avoid data loss while
-	editing data from another server.
+	You can use this to check if a player is active on another server before
+	attempting to edit their data from this server.
 	:::
 
 	@yields
 
 	@return Result<boolean, RobloxAPIError>
 ]=]
-function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxAPIError>
+function Document.IsAvailableAsync<T>(self: Document<T>): Result<boolean, RobloxAPIError>
 	assert(not self._isClosing, "Document is closing")
 
 	if self._open then
@@ -764,7 +748,7 @@ function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxA
 
 	local keyData = checkKeyData(getValue)
 
-	-- Since the behaviour of Open in this case is to put the existing value
+	-- Since the behaviour of OpenAsync in this case is to put the existing value
 	-- in the key into keyData.data, return a true Result.
 	if not keyData then
 		return {
@@ -783,7 +767,7 @@ function Document.IsOpenAvailable<T>(self: Document<T>): Result<boolean, RobloxA
 end
 
 --[=[
-	Returns whether the document is open or not
+	Returns whether the document is currently open in this server.
 
 	@return boolean
 ]=]
@@ -805,18 +789,18 @@ end
 
 	@yields
 ]=]
-function Document.Close<T>(self: Document<T>): WriteResult<T?>
+function Document.CloseAsync<T>(self: Document<T>): WriteResult<T?>
 	assert(self._open, "Document not open")
 
 	runHooks(self._preHooks.Close)
 
-	-- This causes :Save to also remove the session lock
+	-- This causes :SaveAsync to also remove the session lock
 	self._isClosing = true
 
 	local saveResult: WriteResult<T>
 
 	if self._lockSessions then
-		saveResult = self:Save()
+		saveResult = self:SaveAsync()
 
 		-- Abort the closure if the save failed
 		if not saveResult.success then
@@ -853,7 +837,7 @@ function Document.Close<T>(self: Document<T>): WriteResult<T?>
 end
 
 --[=[
-	Returns true if `:Close` has been called and is incomplete.
+	Returns true if `:CloseAsync` has been called and is incomplete.
 
 	@return boolean
 ]=]
@@ -916,11 +900,11 @@ end
 
 	The document must be open before using this method.
 
-	If using session locking, passing a transform is equvialent to calling
-	`SetCache` with the transformed data and then `Save`.
+	If using session locking, passing a transform is equivalent to calling
+	`SetCache` with the transformed data and then `SaveAsync`.
 	If the Save fails, the cache will still be updated.
 
-	If you only need to update a document once, consider `OpenAndUpdate`.
+	If you only need to update a document once, consider `OpenAndUpdateAsync`.
 
 	Throws if data is not storable or the transform return value is invalid.
 
@@ -936,7 +920,7 @@ end
 
 	:::warning
 	Assumes the data that is already in Data Stores is valid since the last
-	`:Open`. If it isn't, and this is not corrected by the transform, this
+	`:OpenAsync`. If it isn't, and this is not corrected by the transform, this
 	method will throw a luau error.
 	:::
 
@@ -951,7 +935,7 @@ end
 	:::
 
 	:::info
-	Unlike `Open`, this method will not retry if the lock is stolen, and will
+	Unlike `OpenAsync`, this method will not retry if the lock is stolen, and will
 	instead return a `SessionLockedError` after the first attempt.
 	:::
 
@@ -960,7 +944,7 @@ end
 
 	@yields
 ]=]
-function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteResult<T>
+function Document.UpdateAsync<T>(self: Document<T>, transform: Transform<T>): WriteResult<T>
 	assert(self._open, "Document not open")
 
 	runHooks(self._preHooks.Update)
@@ -970,7 +954,7 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 	local notStorable: boolean
 	local schemaError: boolean
 	local notStorableErr: string
-
+	
 	-- We need to do this here since the updateAsync transform could run
 	-- multiple times.
 	if self._lockSessions then
@@ -979,7 +963,7 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 		local updatedData = transform(self._cache)
 		-- Since session locked data requires immutable updates, we can
 		-- get away with just checking references here to avoid running
-		-- SetCache (and firing the signal) for a `:Save` call.
+		-- SetCache (and firing the signal) for a `:SaveAsync` call.
 		if updatedData ~= self._cache then
 			self:SetCache(updatedData)
 		end
@@ -1106,10 +1090,10 @@ function Document.Update<T>(self: Document<T>, transform: Transform<T>): WriteRe
 end
 
 --[=[
-	Saves a Document's cache to its DataStore. Equivalent to calling Update
+	Saves a Document's cache to its DataStore. Equivalent to calling UpdateAsync
 	without transforming the data.
 
-	The document must be open and locked to use this method.
+	The document must be open and session-locked to use this method.
 
 	Returns a WriteResult with the data field being the data saved to Data Stores.
 
@@ -1117,11 +1101,11 @@ end
 
 	@yields
 ]=]
-function Document.Save<T>(self: Document<T>): WriteResult<T>
+function Document.SaveAsync<T>(self: Document<T>): WriteResult<T>
 	assert(self._open, "Document not open")
 	assert(self._lockSessions, "Must be session locked to access cache")
 
-	return self:Update(function(cache)
+	return self:UpdateAsync(function(cache)
 		return cache
 	end)
 end
@@ -1130,7 +1114,7 @@ end
 	Erases all data associated with the key.
 
 	The document must not be open. It is up to you to check if the document
-	is open elsewhere, e.g. via `IsOpenAvailable`.
+	is open elsewhere, e.g. via `IsAvailableAsync`.
 
 	Satisfies compliance with GDPR right of erasure.
 
@@ -1140,7 +1124,7 @@ end
 
 	@yields
 ]=]
-function Document.Erase<T>(self: Document<T>): Result<nil, RobloxAPIError>
+function Document.EraseAsync<T>(self: Document<T>): Result<nil, RobloxAPIError>
 	assert(not self._open, "Cannot erase an open document")
 
 	local success = SaveUtil.removeAsync(self._dataStore, self._key)
@@ -1166,7 +1150,7 @@ end
 
 	:::warning
 	A `SchemaError` will be returned if document has never been opened before,
-	so it is strongly recommended to handle this case, and Open the document
+	so it is strongly recommended to handle this case, and open the document
 	before reading it if possible. This includes when migrating from no library.
 	:::
 
@@ -1176,7 +1160,7 @@ end
 
 	@yields
 ]=]
-function Document.Read<T>(self: Document<T>): ReadResult<T>
+function Document.ReadAsync<T>(self: Document<T>): ReadResult<T>
 	runHooks(self._preHooks.Read)
 
 	local success, getValue: any = SaveUtil.getAsync(self._dataStore, self._key)

--- a/target/roblox/DocumentStore.luau
+++ b/target/roblox/DocumentStore.luau
@@ -102,7 +102,7 @@ function DocumentStore.new<T>(props: DocumentStoreProps<T>): DocumentStore<T>
 		game:BindToClose(function()
 			gameClosing = true
 
-			self:CloseAllDocuments()
+			self:CloseAllDocumentsAsync()
 		end)
 	end
 
@@ -171,15 +171,15 @@ end
 
 	:::warning
 	Yields until all documents are closed. If there is a systematic error
-	in your :Close, for example a hook errors, this could infinitely yield.
+	in your `:CloseAsync`, for example a hook errors, this could infinitely yield.
 	:::
 
-	Closes documents asynchronously when request budget allows, and yields
+	Closes documents asynchronously when request budget allows, and yields until
 	all open documents are closed.
 
 	@yields
 ]=]
-function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
+function DocumentStore.CloseAllDocumentsAsync<T>(self: DocumentStore<T>)
 	local thread = coroutine.running()
 
 	local complete = self._documentsToClose == 0 and self._openingDocuments == 0
@@ -187,7 +187,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 	-- This while loop exists for two reasons:
 	-- 1. if budget is limited, we can wait for
 	-- more to be available before spawning future threads, so documents
-	-- are closed as quickly as possilbe by minimising retries
+	-- are closed as quickly as possible by minimising retries
 	-- 2. ensures documents that are opening and not yet opened when
 	-- this is called are closed.
 	while not complete do
@@ -210,7 +210,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 
 			task.spawn(function()
 				if v:IsOpen() and not v:IsClosing() then
-					v:Close()
+					v:CloseAsync()
 				end
 
 				if v:IsClosing() then
@@ -219,7 +219,7 @@ function DocumentStore.CloseAllDocuments<T>(self: DocumentStore<T>)
 					until not v:IsClosing()
 				end
 
-				-- We decrement this even if the .Close failed so the pass
+				-- We decrement this even if the .CloseAsync failed so the pass
 				-- doesn't hang forever
 				documentsToClose -= 1
 

--- a/tests/lune/MockTests.server.luau
+++ b/tests/lune/MockTests.server.luau
@@ -125,7 +125,7 @@ assert(not tableEquals({ test1 = { "test" } }, { test1 = { "test", "test2" } }))
 
 Test("Opens document with no simulated errors and valid is valid", function()
 	local document = createTestDocumentStore():GetDocument("1")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == true)
 	assert(result.data)
 	testDataCheck(result.data)
@@ -134,21 +134,21 @@ end)
 Test("Can close document", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == true)
-	local result2 = document:Close()
+	local result2 = document:CloseAsync()
 	assert(result2.success == true)
 end)
 
 Test("Can reopen document after closed with session locking", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == true)
-	local result2 = document:Close()
+	local result2 = document:CloseAsync()
 	assert(result2.success == true)
 
-	local result3 = document:Open()
+	local result3 = document:OpenAsync()
 	if not result3.success then
 		error(result3.reason)
 	end
@@ -179,8 +179,8 @@ end)
 Test("Can retrieve the same document if reference exists even if closed", function()
 	local documentStore = createTestDocumentStore()
 	local document1 = documentStore:GetDocument("1")
-	document1:Open()
-	document1:Close()
+	document1:OpenAsync()
+	document1:CloseAsync()
 	local document1_2 = documentStore:GetDocument("1")
 	assert(document1 == document1_2, "Documents not equal")
 end)
@@ -189,19 +189,19 @@ Test("GetDocument returns a new document after an old document is closed", funct
 	local documentStore = createTestDocumentStore()
 	do
 		local document = documentStore:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		testDataCheck(result.data)
-		document:Close()
+		document:CloseAsync()
 		assert(result.success)
 	end
 	do
 		local document = documentStore:GetDocument("1")
 
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		testDataCheck(result.data)
-		document:Close()
+		document:CloseAsync()
 		assert(result.success)
 	end
 end)
@@ -210,22 +210,22 @@ Test("Opens document with simulated error", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	mockDataStore.errors:addSimulatedErrors(1)
 	local document = documentStore:GetDocument("2")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == true)
 	assert(result.data)
 	testDataCheck(result.data)
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Opens document with 4 simulated errors", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	mockDataStore.errors:addSimulatedErrors(4)
 	local document = documentStore:GetDocument("2")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == true)
 	assert(result.data)
 	testDataCheck(result.data)
-	document:Close()
+	document:CloseAsync()
 end)
 
 -- Now that all operations only use a single datastore API request, we only need
@@ -234,15 +234,15 @@ Test("Fails to open document with 5 simulated errors", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	mockDataStore.errors:addSimulatedErrors(5)
 	local document = documentStore:GetDocument("3")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == false)
 end)
 
 Test("Open fails with CheckError if data corrupted", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	document:Open()
-	document:Close()
+	document:OpenAsync()
+	document:CloseAsync()
 
 	mockDataStore:UpdateAsync("1", function(value)
 		value.data = {
@@ -252,43 +252,43 @@ Test("Open fails with CheckError if data corrupted", function()
 		return value
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(not result.success, "Open didn't fail")
 	assert(result.reason == "CheckError")
 end)
 
-Test("Update fails if not open", function()
+Test("UpdateAsync fails if not open", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 	shouldFail(function()
-		document:Update(function(data: TestData)
+		document:UpdateAsync(function(data: TestData)
 			data.Document = "newString"
 			return data
 		end)
 	end)
 end)
 
-Test("Update fails with invalid transform", function()
+Test("UpdateAsync fails with invalid transform", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 
-	document:Open()
+	document:OpenAsync()
 
 	shouldFail(function()
-		document:Update(function(data)
+		document:UpdateAsync(function(data)
 			return {} :: any
 		end)
 	end)
 end)
 
-Test("Update fails with unsavable data", function()
+Test("UpdateAsync fails with unsavable data", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 
-	document:Open()
+	document:OpenAsync()
 
 	shouldFail(function()
-		document:Update(function(data: TestData)
+		document:UpdateAsync(function(data: TestData)
 			return { Document = "test", Service = 3, 5 }
 		end)
 	end)
@@ -313,11 +313,11 @@ Test("SetCache fails if not open", function()
 	end)
 end)
 
-Test("Save fails if not open", function()
+Test("SaveAsync fails if not open", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 	shouldFail(function()
-		document:Save()
+		document:SaveAsync()
 	end)
 end)
 
@@ -340,11 +340,11 @@ Test("SetCache fails if not session locked", function()
 	end)
 end)
 
-Test("Save fails if not session locked", function()
+Test("SaveAsync fails if not session locked", function()
 	local documentStore = createTestDocumentStoreNotLocked()
 	local document = documentStore:GetDocument("1")
 	shouldFail(function()
-		document:Save()
+		document:SaveAsync()
 	end)
 end)
 
@@ -352,11 +352,11 @@ Test("IsOpen returns correctly", function()
 	local documentStore = createTestDocumentStoreNotLocked()
 	local document = documentStore:GetDocument("1")
 	assert(document:IsOpen() == false)
-	document:Open()
+	document:OpenAsync()
 	assert(document:IsOpen() == true)
 end)
 
-Test("Session locking affects IsOpenAvailable correctly", function()
+Test("Session locking affects IsAvailableAsync correctly", function()
 	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
 
 	local session1 = DocumentService.DocumentStore.new({
@@ -381,29 +381,29 @@ Test("Session locking affects IsOpenAvailable correctly", function()
 	})
 	do
 		local document = session1:GetDocument("sessionLockTest1")
-		local openAvailable = document:IsOpenAvailable()
-		local result = document:Open()
+		local openAvailable = document:IsAvailableAsync()
+		local result = document:OpenAsync()
 		assert(result.success == true)
 		assert(openAvailable.success == true)
 		assert(openAvailable.data == true)
 	end
 	do
 		local document = session2:GetDocument("sessionLockTest1")
-		local result = document:IsOpenAvailable()
+		local result = document:IsAvailableAsync()
 		assert(result.success == true)
 		assert(result.data == false)
 	end
 end)
 
-Test("Data mutations with :Update persist with no migrations", function()
+Test("Data mutations with :UpdateAsync persist with no migrations", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("6")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	if not result.success then
 		error(result.reason)
 	end
 
-	document:Update(function(data: TestData)
+	document:UpdateAsync(function(data: TestData)
 		data = table.clone(data)
 		data.Service = 10000
 		data.Document = "hi!"
@@ -411,8 +411,8 @@ Test("Data mutations with :Update persist with no migrations", function()
 		return data
 	end)
 
-	document:Close()
-	local result2 = document:Open()
+	document:CloseAsync()
+	local result2 = document:OpenAsync()
 	if not result2.success then
 		error(result2.reason)
 	end
@@ -420,7 +420,7 @@ Test("Data mutations with :Update persist with no migrations", function()
 	assert(result2.data.Service == 10000)
 	assert(result2.data.Document == "hi!")
 
-	document:Update(function(data: TestData)
+	document:UpdateAsync(function(data: TestData)
 		data = table.clone(data)
 		data.Service = data.Service + 10000
 		data.Document = data.Document .. "... hi!"
@@ -428,8 +428,8 @@ Test("Data mutations with :Update persist with no migrations", function()
 		return data
 	end)
 
-	document:Close()
-	local result3 = document:Open()
+	document:CloseAsync()
+	local result3 = document:OpenAsync()
 	if not result3.success then
 		error(result3.reason)
 	end
@@ -437,11 +437,11 @@ Test("Data mutations with :Update persist with no migrations", function()
 	assert(result3.data.Document == "hi!... hi!")
 end)
 
-Test("Update succeeds with less than 4 API fails", function()
+Test("UpdateAsync succeeds with less than 4 API fails", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	if not result.success then
 		error(result.reason)
@@ -449,7 +449,7 @@ Test("Update succeeds with less than 4 API fails", function()
 
 	mockDataStore.errors:addSimulatedErrors(4)
 
-	local updateResult = document:Update(function(data: TestData)
+	local updateResult = document:UpdateAsync(function(data: TestData)
 		data = table.clone(data)
 		data.Service = -100
 		data.Document = "hi!"
@@ -460,19 +460,19 @@ Test("Update succeeds with less than 4 API fails", function()
 	assert(updateResult.data.Service == -100)
 end)
 
-Test("Update fails with RobloxAPIFail for 5 or more API fails", function()
+Test("UpdateAsync fails with RobloxAPIFail for 5 or more API fails", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 
 	local document = documentStore:GetDocument("1")
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	if not result.success then
 		error(result.reason)
 	end
 
 	mockDataStore.errors:addSimulatedErrors(5)
 
-	local updateResult = document:Update(function(data: TestData)
+	local updateResult = document:UpdateAsync(function(data: TestData)
 		data = table.clone(data)
 		data.Service = 10000
 		data.Document = "hi!"
@@ -504,16 +504,16 @@ Test("Migrate from an invalid data with no migration should fail with CheckFaile
 	end)
 
 	local document = store:GetDocument("nolibrary2")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success == false)
 	assert(result.reason == "CheckError")
 end)
 
-Test("Close fails if not open", function()
+Test("CloseAsync fails if not open", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 	shouldFail(function()
-		document:Close()
+		document:CloseAsync()
 	end)
 end)
 
@@ -575,14 +575,14 @@ Test("When migrating from from no library with a migration, the migration runs e
 	end)
 
 	local document = store:GetDocument("1")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success)
 	check2(result.data)
 	assert((result.data :: any).rogueData)
 
-	document:Close()
+	document:CloseAsync()
 	document = store:GetDocument("1")
-	local result2 = document:Open()
+	local result2 = document:OpenAsync()
 	assert(result2.success)
 	check2(result2.data)
 
@@ -622,10 +622,10 @@ Test("Migrating from version 0 runs all migrations exactly once", function()
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- Imagine now we update the game and add a migration
@@ -671,16 +671,16 @@ Test("Migrating from version 0 runs all migrations exactly once", function()
 		})
 
 		local document = store:GetDocument("1")
-		document:Open()
-		document:Close()
+		document:OpenAsync()
+		document:CloseAsync()
 		document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
 		assert(result.data.newField == "new field migrated")
 		assert(result.data.testString == "string")
 		assert(result.data.testNumber == 0)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	assert(migrationRunCount == 1, "Migration ran " .. migrationRunCount .. " times, it should run once")
@@ -711,7 +711,7 @@ Test("Using default data never runs migrations", function()
 			testString = "string",
 			testNumber = 0,
 		},
-		-- We assume an earlier version exis
+		-- We assume an earlier version exists
 		migrations = {
 			{
 				backwardsCompatible = true,
@@ -729,21 +729,21 @@ Test("Using default data never runs migrations", function()
 	-- Opening from the first time should use default
 	do
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
 		assert(result.data.testNumber == 0)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- Re-open the document to make sure the version is set/checked correctly
 	do
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
 		assert(result.data.testNumber == 0)
-		document:Close()
+		document:CloseAsync()
 	end
 end)
 
@@ -791,11 +791,11 @@ Test("Migrating from a non-zero version does not run old migrations", function()
 
 		local document = store:GetDocument("1")
 		-- Opening from the first time should use default
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
 		assert(result.data.testNumber == 0)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- Imagine now we update the game and add a migration
@@ -850,16 +850,16 @@ Test("Migrating from a non-zero version does not run old migrations", function()
 		})
 
 		local document = store:GetDocument("1")
-		document:Open()
-		document:Close()
+		document:OpenAsync()
+		document:CloseAsync()
 		document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
 		assert(result.data.newField == "new field migrated")
 		assert(result.data.testString == "string")
 		assert(result.data.testNumber == 0)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	assert(migrationRunCount == 1, "Migration ran " .. migrationRunCount .. " times, it should run once")
@@ -909,10 +909,10 @@ Test("Backwards incompatible schemas fail with BackwardsCompatibilityError", fun
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- We join an old server
@@ -946,7 +946,7 @@ Test("Backwards incompatible schemas fail with BackwardsCompatibilityError", fun
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success == false)
 		assert(result.reason == "BackwardsCompatibilityError")
 	end
@@ -996,10 +996,10 @@ Test("Backwards compatible schemas do not fail to open and preserve additional f
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- We join an old server
@@ -1031,11 +1031,11 @@ Test("Backwards compatible schemas do not fail to open and preserve additional f
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success == true)
 		check(result.data)
 		assert((result.data :: any).newField == "new field default")
-		document:Close()
+		document:CloseAsync()
 	end
 end)
 
@@ -1083,10 +1083,10 @@ Test("Migrations do not re-run after going from latest -> outdated -> latest ses
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- We join an old server
@@ -1118,10 +1118,10 @@ Test("Migrations do not re-run after going from latest -> outdated -> latest ses
 		})
 
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	-- We now join a new server
@@ -1166,18 +1166,18 @@ Test("Migrations do not re-run after going from latest -> outdated -> latest ses
 		})
 
 		local document = store:GetDocument("1")
-		local result1 = document:Open()
+		local result1 = document:OpenAsync()
 		assert(result1.success, if not result1.success then result1.reason else "")
-		document:Close()
+		document:CloseAsync()
 		document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 		check(result.data)
-		document:Close()
+		document:CloseAsync()
 	end
 end)
 
-Test("DocumentStore:CloseAllDocuments yields until all documents are closed", function()
+Test("DocumentStore:CloseAllDocumentsAsync yields until all documents are closed", function()
 	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
 
 	-- We join a new server
@@ -1218,22 +1218,22 @@ Test("DocumentStore:CloseAllDocuments yields until all documents are closed", fu
 
 	do
 		local document = store:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 	end
 	do
 		local document = store:GetDocument("2")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(result.success)
 	end
 	do
 		local document = store:GetDocument("3")
-		local result = document:Open()
+		local result = document:OpenAsync()
 	end
 	do
 		local document = store:GetDocument("4")
-		local result = document:Open()
-		document:Close()
+		local result = document:OpenAsync()
+		document:CloseAsync()
 	end
 	do
 		local document = store:GetDocument("5")
@@ -1250,7 +1250,7 @@ Test("DocumentStore:CloseAllDocuments yields until all documents are closed", fu
 	assert(store:GetDocument("3"):IsOpen() == true)
 	assert(store:GetDocument("4"):IsOpen() == false)
 	assert(store:GetDocument("5"):IsOpen() == false)
-	store:CloseAllDocuments()
+	store:CloseAllDocumentsAsync()
 	assert(store:GetDocument("1"):IsOpen() == false)
 	assert(store:GetDocument("2"):IsOpen() == false)
 	assert(store:GetDocument("3"):IsOpen() == false)
@@ -1258,51 +1258,51 @@ Test("DocumentStore:CloseAllDocuments yields until all documents are closed", fu
 	assert(store:GetDocument("5"):IsOpen() == false)
 end)
 
-Test("Erase method sets the key to nil", function()
+Test("EraseAsync method sets the key to nil", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success)
 	assert(mockDataStore:GetAsync("1") ~= nil)
-	document:Close()
+	document:CloseAsync()
 	document = documentStore:GetDocument("1")
-	document:Erase()
+	document:EraseAsync()
 	assert(mockDataStore:GetAsync("1") == nil)
 end)
 
-Test("Read fails with SchemaError if key not initialised", function()
+Test("ReadAsync fails with SchemaError if key not initialised", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local result = document:Read()
+	local result = document:ReadAsync()
 	assert(not result.success, "Read didn't fail")
 	assert(result.reason == "SchemaError")
 end)
 
-Test("Read correctly reads data set properly", function()
+Test("ReadAsync correctly reads data set properly", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
-	local result = document:Read()
+	local result = document:ReadAsync()
 	assert(result.success)
 	assert(tableEquals(openResult.data, result.data))
 end)
 
-Test("Read fails with SchemaError if key corrupted", function()
+Test("ReadAsync fails with SchemaError if key corrupted", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 	mockDataStore:write("1", {})
-	local result = document:Read()
+	local result = document:ReadAsync()
 	assert(not result.success, "Read didn't fail")
 	assert(result.reason == "SchemaError")
 end)
 
-Test("Read fails with CheckError if data corrupted", function()
+Test("ReadAsync fails with CheckError if data corrupted", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 	mockDataStore:UpdateAsync("1", function(value)
 		value.data = {
@@ -1311,12 +1311,12 @@ Test("Read fails with CheckError if data corrupted", function()
 		}
 		return value
 	end)
-	local result = document:Read()
+	local result = document:ReadAsync()
 	assert(not result.success, "Read didn't fail")
 	assert(result.reason == "CheckError")
 end)
 
-Test("Read runs migrations correctly", function()
+Test("ReadAsync runs migrations correctly", function()
 	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
 
 	local CheckInterface1 = {
@@ -1391,67 +1391,67 @@ Test("Read runs migrations correctly", function()
 
 	do
 		local document = storeVersion0:GetDocument("1")
-		document:Open()
-		document:Close()
+		document:OpenAsync()
+		document:CloseAsync()
 	end
 	do
 		local document = storeVersion1:GetDocument("1")
-		local result = document:Read()
+		local result = document:ReadAsync()
 		assert(result.success)
 		check2(result.data)
-		local result2 = document:Read()
+		local result2 = document:ReadAsync()
 		assert(result2.success)
 		check2(result2.data)
-		local result3 = document:Open()
+		local result3 = document:OpenAsync()
 		assert(result3.success)
 		check2(result3.data)
-		local result4 = document:Read()
+		local result4 = document:ReadAsync()
 		assert(result4.success)
 		check2(result4.data)
-		document:Close()
+		document:CloseAsync()
 	end
 
 	assert(migrationRunCount == 3, "Migration should run 3 times")
 end)
 
-Test("Update fails with SchemaError if key corrupted", function()
+Test("UpdateAsync fails with SchemaError if key corrupted", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 	mockDataStore:write("1", {})
-	local result = document:Update(function(value)
+	local result = document:UpdateAsync(function(value)
 		return value
 	end)
 	assert(not result.success, "Update didn't fail")
 	assert(result.reason == "SchemaError")
 end)
 
-Test("Update fails with a luau error if it corrupts the data", function()
+Test("UpdateAsync fails with a luau error if it corrupts the data", function()
 	local documentStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 	shouldFail(function()
-		document:Update(function()
+		document:UpdateAsync(function()
 			return {
 				data = "This isn't right!",
 			} :: any
 		end)
 	end)
 	shouldFail(function()
-		document:Update(function()
+		document:UpdateAsync(function()
 			return nil :: any
 		end)
 	end)
 end)
 
-Test(":Steal will correctly steal a sesion", function()
+Test(":Steal will correctly steal a session", function()
 	-- Session 1
 	do
 		local documentStore = createTestDocumentStore()
 		local document = documentStore:GetDocument("1")
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(openResult.success)
 	end
 
@@ -1460,12 +1460,12 @@ Test(":Steal will correctly steal a sesion", function()
 		local documentStore = createTestDocumentStore()
 		local document = documentStore:GetDocument("1")
 		document:Steal()
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(openResult.success)
 	end
 end)
 
-Test("If the lock is stolen, Update, Save, Close return SessionLockedError", function()
+Test("If the lock is stolen, UpdateAsync, SaveAsync, CloseAsync return SessionLockedError", function()
 	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
 
 	local session1 = DocumentService.DocumentStore.new({
@@ -1490,20 +1490,20 @@ Test("If the lock is stolen, Update, Save, Close return SessionLockedError", fun
 	})
 
 	local document = session1:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 
 	-- Session 2 steals the lock
 	do
 		local document2 = session2:GetDocument("1")
 		document2:Steal()
-		local result = document2:Open()
+		local result = document2:OpenAsync()
 		assert(result.success)
 	end
 
-	-- Test Update
+	-- Test UpdateAsync
 	do
-		local result = document:Update(function(value)
+		local result = document:UpdateAsync(function(value)
 			return value
 		end)
 
@@ -1511,17 +1511,17 @@ Test("If the lock is stolen, Update, Save, Close return SessionLockedError", fun
 		assert(result.reason == "SessionLockedError")
 	end
 
-	-- Test Save
+	-- Test SaveAsync
 	do
-		local result = document:Save()
+		local result = document:SaveAsync()
 
 		assert(not result.success)
 		assert(result.reason == "SessionLockedError")
 	end
 
-	-- Test Close
+	-- Test CloseAsync
 	do
-		local result = document:Close()
+		local result = document:CloseAsync()
 
 		assert(not result.success)
 		assert(result.reason == "SessionLockedError")
@@ -1555,14 +1555,14 @@ Test("Opening a locked document returns SessionLockedError", function()
 
 	do
 		local document = session1:GetDocument("1")
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(openResult.success)
 	end
 
 	-- Session 2
 	do
 		local document = session2:GetDocument("1")
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(not result.success)
 		assert(result.reason == "SessionLockedError")
 	end
@@ -1593,7 +1593,7 @@ Test("Opening a locked document will retry if session locked", function()
 	})
 
 	local document1 = session1:GetDocument("1")
-	local openResult = document1:Open()
+	local openResult = document1:OpenAsync()
 	assert(openResult.success)
 
 	-- Session 2
@@ -1602,18 +1602,18 @@ Test("Opening a locked document will retry if session locked", function()
 	task.spawn(function()
 		local document2 = session2:GetDocument("1")
 		-- This should initially fail, and then retry and succeed
-		result = document2:Open()
+		result = document2:OpenAsync()
 
 		task.defer(thread)
 	end)
 	task.spawn(function()
 		task.wait()
-		document1:Close()
+		document1:CloseAsync()
 	end)
 
 	coroutine.yield()
 
-	-- This will only pass if Open is tried again
+	-- This will only pass if OpenAsync is tried again
 	assert(result.success)
 end)
 
@@ -1621,7 +1621,7 @@ Test("Cache is set correctly opening a document", function()
 	local documentStore = createTestDocumentStore()
 
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 
 	assert(tableEquals(document:GetCache(), openResult.data))
@@ -1631,10 +1631,10 @@ Test("Cache is set correctly updating a document", function()
 	local documentStore = createTestDocumentStore()
 
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 
-	local result = document:Update(function(data: TestData)
+	local result = document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated data!"
 
@@ -1650,12 +1650,12 @@ Test("Error if cache is mutated", function()
 	local documentStore = createTestDocumentStore()
 
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 
 	do
 		local success
-		document:Update(function(data: TestData)
+		document:UpdateAsync(function(data: TestData)
 			success = pcall(function()
 				data.Document = "Updated data!"
 			end)
@@ -1684,7 +1684,7 @@ Test(":SetCache, :GetCache work correctly in the same session", function()
 	local documentStore = createTestDocumentStore()
 
 	local document = documentStore:GetDocument("1")
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(openResult.success)
 
 	local newCache = {
@@ -1706,18 +1706,18 @@ Test("Cache updates persist between sessions (are saved on close)", function()
 
 	do
 		local document = documentStore:GetDocument("1")
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(openResult.success)
 
 		document:SetCache(newCache)
-		assert(document:Close().success)
+		assert(document:CloseAsync().success)
 	end
 	do
 		local document = documentStore:GetDocument("1")
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(openResult.success)
 		assert(tableEquals(openResult.data, newCache))
-		assert(document:Close().success)
+		assert(document:CloseAsync().success)
 	end
 end)
 
@@ -1743,14 +1743,14 @@ Test("Open Hooks run correctly", function()
 		failRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(hook2Ran, "Hook didn't run")
 	assert(result.success, "Open failed")
-	document:Close()
+	document:CloseAsync()
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(not openResult.success, "Open succeeded")
 	assert(failRan)
 end)
@@ -1778,14 +1778,14 @@ Test("Open Hooks cleanup run correctly", function()
 		failRan = pcall(cleanupFail)
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(hook2CleanupRan, "Hook didn't run")
 	assert(result.success, "Open failed")
-	document:Close()
+	document:CloseAsync()
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(not openResult.success, "Open succeeded")
 	assert(failRan)
 end)
@@ -1833,19 +1833,19 @@ Test("Open Hooks run even if cleaned up while executing hooks", function()
 		secondFailRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success, "Open failed")
 	assert(firstBeforeRan)
 	assert(secondBeforeRan)
 	assert(firstAfterRan)
 	assert(secondAfterRan)
-	local resultClose = document:Close()
+	local resultClose = document:CloseAsync()
 	assert(resultClose.success, "Close failed")
 	assert(not firstFailRan)
 	assert(not secondFailRan)
 
 	mockDataStore.errors:addSimulatedErrors(5)
-	result = document:Open()
+	result = document:OpenAsync()
 	assert(not result.success, "Open succeeded")
 	assert(firstFailRan)
 	assert(secondFailRan)
@@ -1871,20 +1871,20 @@ Test("Close Hooks run correctly", function()
 		failRan = true
 	end)
 
-	local result = document:Open()
-	local resultClose = document:Close()
+	local result = document:OpenAsync()
+	local resultClose = document:CloseAsync()
 	assert(hook2Ran, "Hook didn't run")
 	assert(result.success, "Open failed")
 	assert(resultClose.success, "Close failed")
 
-	document:Open()
+	document:OpenAsync()
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	local closeResult = document:Close()
+	local closeResult = document:CloseAsync()
 	assert(not closeResult.success, "Close succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Close Hooks cleanup run correctly", function()
@@ -1910,20 +1910,20 @@ Test("Close Hooks cleanup run correctly", function()
 		failRan = pcall(cleanupFail)
 	end)
 
-	local result = document:Open()
-	local resultClose = document:Close()
+	local result = document:OpenAsync()
+	local resultClose = document:CloseAsync()
 	assert(hook2CleanupRan, "Hook didn't run")
 	assert(result.success, "Open failed")
 	assert(resultClose.success, "Close failed")
 
-	document:Open()
+	document:OpenAsync()
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	local closeResult = document:Close()
+	local closeResult = document:CloseAsync()
 	assert(not closeResult.success, "Close succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Close Hooks run even if cleaned up while executing hooks", function()
@@ -1969,8 +1969,8 @@ Test("Close Hooks run even if cleaned up while executing hooks", function()
 		secondFailRan = true
 	end)
 
-	local result = document:Open()
-	local resultClose = document:Close()
+	local result = document:OpenAsync()
+	local resultClose = document:CloseAsync()
 	assert(result.success, "Open failed")
 	assert(resultClose.success, "Close failed")
 	assert(firstBeforeRan)
@@ -1980,9 +1980,9 @@ Test("Close Hooks run even if cleaned up while executing hooks", function()
 	assert(not firstFailRan)
 	assert(not secondFailRan)
 
-	document:Open()
+	document:OpenAsync()
 	mockDataStore.errors:addSimulatedErrors(5)
-	resultClose = document:Close()
+	resultClose = document:CloseAsync()
 	assert(not resultClose.success, "Close succeeded")
 	assert(firstFailRan)
 	assert(secondFailRan)
@@ -1998,11 +1998,11 @@ Test("Before Update Hooks run correctly", function()
 		hookRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	assert(result.success, "Open failed")
 
-	local updateResult = document:Update(function(data: TestData)
+	local updateResult = document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2012,7 +2012,7 @@ Test("Before Update Hooks run correctly", function()
 	assert(hookRan, "Hook didn't run")
 	assert(updateResult.success)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Before Update Hooks cleanup run correctly", function()
@@ -2025,11 +2025,11 @@ Test("Before Update Hooks cleanup run correctly", function()
 	end)
 	hookRan = pcall(cleanup)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	assert(result.success, "Open failed")
 
-	local updateResult = document:Update(function(data: TestData)
+	local updateResult = document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2039,7 +2039,7 @@ Test("Before Update Hooks cleanup run correctly", function()
 	assert(hookRan, "Hook didn't run")
 	assert(updateResult.success)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("After Update Hooks run correctly", function()
@@ -2052,10 +2052,10 @@ Test("After Update Hooks run correctly", function()
 		hookRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success, "Open failed")
 
-	document:Update(function(data: TestData)
+	document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2064,7 +2064,7 @@ Test("After Update Hooks run correctly", function()
 
 	assert(hookRan, "Hook didn't run")
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("After Update Hooks cleanup run correctly", function()
@@ -2078,10 +2078,10 @@ Test("After Update Hooks cleanup run correctly", function()
 	end)
 	hookRan = pcall(cleanup)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success, "Open failed")
 
-	document:Update(function(data: TestData)
+	document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2090,7 +2090,7 @@ Test("After Update Hooks cleanup run correctly", function()
 
 	assert(hookRan, "Hook didn't run")
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Fail Update Hooks run correctly", function()
@@ -2103,10 +2103,10 @@ Test("Fail Update Hooks run correctly", function()
 	end)
 
 	assert(not failRan)
-	document:Open()
+	document:OpenAsync()
 	mockDataStore.errors:addSimulatedErrors(5)
 
-	local result = document:Update(function(data: TestData)
+	local result = document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2116,7 +2116,7 @@ Test("Fail Update Hooks run correctly", function()
 	assert(not result.success, "Update succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Fail Update Hooks cleanup run correctly", function()
@@ -2130,10 +2130,10 @@ Test("Fail Update Hooks cleanup run correctly", function()
 	end)
 
 	assert(not failRan)
-	document:Open()
+	document:OpenAsync()
 	mockDataStore.errors:addSimulatedErrors(5)
 
-	local result = document:Update(function(data: TestData)
+	local result = document:UpdateAsync(function(data: TestData)
 		local newData = table.clone(data)
 		newData.Document = "Updated"
 
@@ -2143,7 +2143,7 @@ Test("Fail Update Hooks cleanup run correctly", function()
 	assert(not result.success, "Update succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Update Hooks run even if cleaned up while executing hooks", function()
@@ -2189,12 +2189,11 @@ Test("Update Hooks run even if cleaned up while executing hooks", function()
 		secondFailRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	assert(result.success, "Open failed")
 
-	local updateResult = document:Update(function(data: TestData)
-		-- We don't really need to test for changes made here if the previous tests pass
+	local updateResult = document:UpdateAsync(function(data: TestData)
 		return table.clone(data)
 	end)
 
@@ -2208,14 +2207,14 @@ Test("Update Hooks run even if cleaned up while executing hooks", function()
 
 	mockDataStore.errors:addSimulatedErrors(5)
 
-	document:Update(function(data: TestData)
+	document:UpdateAsync(function(data: TestData)
 		return table.clone(data)
 	end)
 
 	assert(firstFailRan)
 	assert(secondFailRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Read Hooks cleanup run correctly", function()
@@ -2239,19 +2238,19 @@ Test("Read Hooks cleanup run correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
-	local resultRead = document:Read()
+	local result = document:OpenAsync()
+	local resultRead = document:ReadAsync()
 	assert(resultRead.success, "Read failed")
 	assert(secondCleanupRan, "After hook didn't run")
 	assert(result.success, "Open failed")
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	resultRead = document:Read()
+	resultRead = document:ReadAsync()
 	assert(not resultRead.success, "Read succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Read Hooks run correctly", function()
@@ -2275,19 +2274,19 @@ Test("Read Hooks run correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
-	local resultRead = document:Read()
+	local result = document:OpenAsync()
+	local resultRead = document:ReadAsync()
 	assert(resultRead.success, "Read failed")
 	assert(secondRan, "After hook didn't run")
 	assert(result.success, "Open failed")
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	resultRead = document:Read()
+	resultRead = document:ReadAsync()
 	assert(not resultRead.success, "Read succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 -- Sleitnick Signal is well-established and tested, so we do not need
@@ -2307,22 +2306,22 @@ Test("Read signals fire correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
-	local resultRead = document:Read()
+	local result = document:OpenAsync()
+	local resultRead = document:ReadAsync()
 	assert(resultRead.success, "Read failed")
 	assert(secondRan, "Success signal didn't run")
 	assert(result.success, "Open failed")
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	resultRead = document:Read()
+	resultRead = document:ReadAsync()
 	assert(not resultRead.success, "Read succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
--- This test relies on the fact that `:Save` calls Update
+-- This test relies on the fact that `:SaveAsync` calls UpdateAsync
 -- to avoid very repetitive unit tests
 Test("Update signals fire correctly", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
@@ -2339,19 +2338,19 @@ Test("Update signals fire correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
-	local saveResult = document:Save()
+	local result = document:OpenAsync()
+	local saveResult = document:SaveAsync()
 	assert(saveResult.success, "Save failed")
 	assert(secondRan, "Success signal didn't run")
 	assert(result.success, "Open failed")
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	saveResult = document:Save()
+	saveResult = document:SaveAsync()
 	assert(not saveResult.success, "Save succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Closed signals fire correctly", function()
@@ -2369,20 +2368,20 @@ Test("Closed signals fire correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
-	local closeResult = document:Close()
+	local result = document:OpenAsync()
+	local closeResult = document:CloseAsync()
 	assert(closeResult.success, "Close failed")
 	assert(secondRan, "Success signal didn't run")
 	assert(result.success, "Open failed")
 
 	assert(not failRan)
-	document:Open()
+	document:OpenAsync()
 	mockDataStore.errors:addSimulatedErrors(5)
-	closeResult = document:Close()
+	closeResult = document:CloseAsync()
 	assert(not closeResult.success, "Close succeeded")
 	assert(failRan)
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Open signals fire correctly", function()
@@ -2399,14 +2398,14 @@ Test("Open signals fire correctly", function()
 		end
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(secondRan, "Hook didn't run")
 	assert(result.success, "Open failed")
-	document:Close()
+	document:CloseAsync()
 
 	assert(not failRan)
 	mockDataStore.errors:addSimulatedErrors(5)
-	local openResult = document:Open()
+	local openResult = document:OpenAsync()
 	assert(not openResult.success, "Open succeeded")
 	assert(failRan)
 end)
@@ -2454,8 +2453,8 @@ Test("Read Hooks run even if cleaned up while executing hooks", function()
 		secondFailRan = true
 	end)
 
-	local result = document:Open()
-	local resultRead = document:Read()
+	local result = document:OpenAsync()
+	local resultRead = document:ReadAsync()
 	assert(result.success, "Open failed")
 	assert(resultRead.success, "Read failed")
 	assert(firstBeforeRan)
@@ -2466,7 +2465,7 @@ Test("Read Hooks run even if cleaned up while executing hooks", function()
 	assert(not secondFailRan)
 
 	mockDataStore.errors:addSimulatedErrors(5)
-	resultRead = document:Read()
+	resultRead = document:ReadAsync()
 	assert(not resultRead.success, "Read succeeded")
 	assert(firstFailRan)
 	assert(secondFailRan)
@@ -2498,13 +2497,13 @@ Test("Open Once Hooks run correctly", function()
 	end)
 
 	for _ = 1, 2 do
-		local result = document:Open()
+		local result = document:OpenAsync()
 		assert(hook2Ran, "Hook didn't run")
 		assert(result.success, "Open failed")
-		document:Close()
+		document:CloseAsync()
 
 		mockDataStore.errors:addSimulatedErrors(5)
-		local openResult = document:Open()
+		local openResult = document:OpenAsync()
 		assert(not openResult.success, "Open succeeded")
 		assert(failRan)
 	end
@@ -2538,19 +2537,19 @@ Test("Close Once Hooks run correctly", function()
 	end)
 
 	for _ = 1, 2 do
-		local result = document:Open()
-		local resultClose = document:Close()
+		local result = document:OpenAsync()
+		local resultClose = document:CloseAsync()
 		assert(hook2Ran, "Hook didn't run")
 		assert(result.success, "Open failed")
 		assert(resultClose.success, "Close failed")
 
-		document:Open()
+		document:OpenAsync()
 		mockDataStore.errors:addSimulatedErrors(5)
-		local closeResult = document:Close()
+		local closeResult = document:CloseAsync()
 		assert(not closeResult.success, "Close succeeded")
 		assert(failRan)
 
-		document:Close()
+		document:CloseAsync()
 	end
 end)
 
@@ -2565,12 +2564,12 @@ Test("Update Once Before Hooks run correctly", function()
 		hookRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	assert(result.success, "Open failed")
 
 	for _ = 1, 2 do
-		local updateResult = document:Update(function(data: TestData)
+		local updateResult = document:UpdateAsync(function(data: TestData)
 			local newData = table.clone(data)
 			newData.Document = "Updated"
 
@@ -2581,7 +2580,7 @@ Test("Update Once Before Hooks run correctly", function()
 		assert(updateResult.success)
 	end
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Update Once After Hooks run correctly", function()
@@ -2595,11 +2594,11 @@ Test("Update Once After Hooks run correctly", function()
 		hookRan = true
 	end)
 
-	local result = document:Open()
+	local result = document:OpenAsync()
 	assert(result.success, "Open failed")
 
 	for _ = 1, 2 do
-		document:Update(function(data: TestData)
+		document:UpdateAsync(function(data: TestData)
 			local newData = table.clone(data)
 			newData.Document = "Updated"
 
@@ -2609,7 +2608,7 @@ Test("Update Once After Hooks run correctly", function()
 		assert(hookRan, "Hook didn't run")
 	end
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Fail Update Hooks run correctly", function()
@@ -2623,11 +2622,11 @@ Test("Fail Update Hooks run correctly", function()
 	end)
 
 	assert(not failRan)
-	document:Open()
+	document:OpenAsync()
 
 	for _ = 1, 2 do
 		mockDataStore.errors:addSimulatedErrors(5)
-		local result = document:Update(function(data: TestData)
+		local result = document:UpdateAsync(function(data: TestData)
 			local newData = table.clone(data)
 			newData.Document = "Updated"
 
@@ -2638,7 +2637,7 @@ Test("Fail Update Hooks run correctly", function()
 		assert(failRan)
 	end
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Read Once Hooks run correctly", function()
@@ -2665,28 +2664,28 @@ Test("Read Once Hooks run correctly", function()
 	end)
 
 	-- Open the document first so we don't get SchemaError
-	local result = document:Open()
+	local result = document:OpenAsync()
 
 	for _ = 1, 2 do
-		local resultRead = document:Read()
+		local resultRead = document:ReadAsync()
 		assert(resultRead.success, "Read failed")
 		assert(secondRan, "After hook didn't run")
 		assert(result.success, "Open failed")
 
 		mockDataStore.errors:addSimulatedErrors(5)
-		resultRead = document:Read()
+		resultRead = document:ReadAsync()
 		assert(not resultRead.success, "Read succeeded")
 		assert(failRan)
 	end
 
-	document:Close()
+	document:CloseAsync()
 end)
 
 Test("Open documents are not garbage collected", function()
 	local documentStore = createTestDocumentStore()
 	do
 		local document = documentStore:GetDocument("1")
-		assert(document:Open().success)
+		assert(document:OpenAsync().success)
 	end
 	local _ = (collectgarbage :: any)("collect")
 	local _document, newlyCreated = documentStore:GetDocument("1")
@@ -2704,41 +2703,41 @@ Test("Documents are garbage collected if closed", function()
 			upvalue += 1
 		end)
 
-		document:Open()
-		document:Close()
+		document:OpenAsync()
+		document:CloseAsync()
 	end
 	local _ = (collectgarbage :: any)("collect")
 	local _document, newlyCreated = documentStore:GetDocument("1")
 	assert(newlyCreated)
 end)
 
-Test("OpenAndUpdate fails with invalid transform", function()
+Test("OpenAndUpdateAsync fails with invalid transform", function()
 	local documentStore = createTestDocumentStoreNotLocked()
 	local document = documentStore:GetDocument("1")
 
 	shouldFail(function()
-		document:OpenAndUpdate(function(data)
+		document:OpenAndUpdateAsync(function(data)
 			return {} :: any
 		end)
 	end)
 end)
 
-Test("OpenAndUpdate fails with unsavable data", function()
+Test("OpenAndUpdateAsync fails with unsavable data", function()
 	local documentStore = createTestDocumentStoreNotLocked()
 	local document = documentStore:GetDocument("1")
 
 	shouldFail(function()
-		document:OpenAndUpdate(function(data: TestData)
+		document:OpenAndUpdateAsync(function(data: TestData)
 			return { Document = "test", Service = 3, 5 }
 		end)
 	end)
 end)
 
-Test("OpenAndUpdate mutates data correctly", function()
+Test("OpenAndUpdateAsync mutates data correctly", function()
 	local documentStore = createTestDocumentStoreNotLocked()
 	local document = documentStore:GetDocument("1")
 
-	document:OpenAndUpdate(function(data: TestData)
+	document:OpenAndUpdateAsync(function(data: TestData)
 		data = table.clone(data)
 		data.Service = 10000
 		data.Document = "hi!"
@@ -2746,8 +2745,8 @@ Test("OpenAndUpdate mutates data correctly", function()
 		return data
 	end)
 
-	document:Close()
-	local result2 = document:Open()
+	document:CloseAsync()
+	local result2 = document:OpenAsync()
 	if not result2.success then
 		error(result2.reason)
 	end
@@ -2756,16 +2755,16 @@ Test("OpenAndUpdate mutates data correctly", function()
 	assert(result2.data.Document == "hi!")
 end)
 
-Test("Update does not revert cache updates", function()
+Test("UpdateAsync does not revert cache updates", function()
 	local documentStore, mockDataStore = createTestDocumentStore()
 	local document = documentStore:GetDocument("1")
 
-	document:Open()
+	document:OpenAsync()
 
 	mockDataStore.yield:startYield()
 
 	task.spawn(function()
-		document:Update(function(data: any)
+		document:UpdateAsync(function(data: any)
 			print(data)
 			return table.clone(data) :: any
 		end)
@@ -2780,7 +2779,7 @@ Test("Update does not revert cache updates", function()
 	assert(document:GetCache() == newCache and document:GetCache().Document == "changed")
 end)
 
-Test("Migration errors result in Open erroring", function()
+Test("Migration errors result in OpenAsync erroring", function()
 	local mockDataStore = MockDataStoreService.new():GetDataStore("1")
 
 	local CheckInterface = {
@@ -2828,11 +2827,11 @@ Test("Migration errors result in Open erroring", function()
 	})
 
 	local document = store0:GetDocument("1")
-	document:Open()
-	document:Close()
+	document:OpenAsync()
+	document:CloseAsync()
 	document = store1:GetDocument("1")
 	shouldFail(function()
-		document:Open()
+		document:OpenAsync()
 	end)
 end)
 


### PR DESCRIPTION
closes #108

renamed all the yielding methods to use the async suffix across the codebase

## what changed

**Document.luau**
- `Open` → `OpenAsync`
- `OpenAndUpdate` → `OpenAndUpdateAsync`
- `Close` → `CloseAsync`
- `Save` → `SaveAsync`
- `Update` → `UpdateAsync`
- `Read` → `ReadAsync`
- `Erase` → `EraseAsync`
- `IsOpenAvailable` → `IsAvailableAsync`

**DocumentStore.luau**
- updated all method usages to match

**docs**
- updated all method references in `cache.md`, `opening.md`, and `tutorial.md`
- also snuck in a typo fix: "Seperation" → "Separation"

**tests**
- also updated `MockTests.server.luau` to use the new methods